### PR TITLE
Make $custom fool-proof

### DIFF
--- a/app/Core/View.php
+++ b/app/Core/View.php
@@ -62,7 +62,7 @@ class View
             }
         }
 
-        if ($custom == false) {
+        if ($custom === false) {
             require "app/templates/".TEMPLATE."/$path.php";
         } else {
             require "app/templates/$custom/$path.php";


### PR DESCRIPTION
People might put $custom on 0, "0" or "false"
Let's make sure they don't fool the system