### PR TITLE
Update Csrf.php & Create Request.php

### DIFF
--- a/app/Helpers/Request.php
+++ b/app/Helpers/Request.php
@@ -1,0 +1,77 @@
+<?php
+namespace Helpers;
+
+/*
+ * Request Class
+ *
+ * It contains the request information and provide methods to fetch request body
+ */
+class Request{
+
+    /**
+     * safer and better access to $_POST
+     *
+     * @param  string   $key
+     * @static static method
+     * @return mixed
+     */
+    public static function post($key){
+        return array_key_exists($key, $_POST)? $_POST[$key]: null;
+    }
+
+    /**
+     * safer and better access to $_FILES
+     *
+     * @param  string   $key
+     * @static static method
+     * @return mixed
+     */
+    public static function files($key){
+        return array_key_exists($key, $_FILES)? $_FILES[$key]: null;
+    }
+
+    /**
+     * safer and better access to $_GET
+     *
+     * @param  string   $key
+     * @static static method
+     * @return mixed
+     */
+    public static function query($key){
+        return array_key_exists($key, $_GET)? $_GET[$key]: null;
+    }
+
+    /**
+     * detect if request is Ajax
+     *
+     * @static static method
+     * @return boolean
+     */
+    public static function isAjax(){
+        if(!empty($_SERVER['HTTP_X_REQUESTED_WITH'])){
+            return strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) === 'xmlhttprequest';
+        }
+        return false;
+    }
+
+    /**
+     * detect if request is POST request
+     *
+     * @static static method
+     * @return boolean
+     */
+    public static function isPost(){
+        return $_SERVER["REQUEST_METHOD"] === "POST";
+    }
+
+    /**
+     * detect if request is GET request
+     *
+     * @static static method
+     * @return boolean
+     */
+    public static function isGet(){
+        return $_SERVER["REQUEST_METHOD"] === "GET";
+    }
+
+}


### PR DESCRIPTION
The current implementation of CSRF tokens can be enhanced:

1 . The current implementation is per-form; means if you have multiple opened pages from your website, and each page has a form, you will ending up having different tokens in each form.

+ This could result in invalid CSRF token while the form is submitted from legitimate user(not faked).
**Please** check this [thread](http://stackoverflow.com/questions/10466241/new-csrf-token-per-request-or-not?lq=1) 
+ Adding expiry date is better for making it more secured.

2 . It's painful to re-write the following snippet in every view page.
```php
    use Helpers\Session;
    $token = trim($data['token']);
    Session::set('token', $token);
```
Instead this should work 
```
    <input type="hidden" name="csrf_token" value="<?= $data['csrf_token']; ?>" />
```

3 . As well, validating the CSRF token could be encapsulated in a method. You may want to validate if the HTTP Method is POST before calling this method.
```php
    if (!Csrf::isTokenValid()) {
    }
```