### PR TITLE
Adding check for key in pull and return null if key doesn't exists in session

### DIFF
--- a/app/Helpers/Session.php
+++ b/app/Helpers/Session.php
@@ -59,13 +59,16 @@ class Session
      *
      * @param  string $key item to extract
      *
-     * @return string      return item
+     * @return mixed|null      return item or null when key does not exists
      */
     public static function pull($key)
     {
-        $value = $_SESSION[SESSION_PREFIX.$key];
-        unset($_SESSION[SESSION_PREFIX.$key]);
-        return $value;
+        if (isset($_SESSION[SESSION_PREFIX.$key])) {
+            $value = $_SESSION[SESSION_PREFIX.$key];
+            unset($_SESSION[SESSION_PREFIX.$key]);
+            return $value;
+        }
+        return null;
     }
 
     /**
@@ -74,7 +77,7 @@ class Session
      * @param  string  $key       item to look for in session
      * @param  boolean $secondkey if used then use as a second key
      *
-     * @return string             returns the key
+     * @return mixed|null         returns the key value, or null if key doesn't exists
      */
     public static function get($key, $secondkey = false)
     {
@@ -87,7 +90,7 @@ class Session
                 return $_SESSION[SESSION_PREFIX.$key];
             }
         }
-        return false;
+        return null;
     }
 
     /**


### PR DESCRIPTION
Adding check for key in pull and will return null instead of false on get (and pull too) so it doesn't get confusing when getting boolean from session. 

Can be breaking if you are now checking for === false on the return of get! But this will be better to get objects or mixed types (and not only strings) from session.