### PR TITLE
autoDispatch when project not at root and parameters not as array

### DIFF
--- a/app/Core/Router.php
+++ b/app/Core/Router.php
@@ -132,6 +132,10 @@ class Router
     public static function autoDispatch()
     {
         $uri = parse_url($_SERVER['QUERY_STRING'], PHP_URL_PATH);
+        $uri = '/'.$uri;
+		if (strpos($uri,DIR) === 0) {
+			$uri=substr($uri,strlen(DIR));
+		}
         $uri = trim($uri, ' /');
         $uri = ($amp = strpos($uri, '&')) !== false ? substr($uri, 0, $amp) : $uri;
 
@@ -155,7 +159,7 @@ class Router
         $c = new $controller;
 
         if (method_exists($c, $method)) {
-            $c->$method($args);
+			call_user_func_array(array($c,$method),$args);
             //found method so stop
             return true;
         }


### PR DESCRIPTION
I removed the content of DIR from the path so that when the project is not at the root of the url, autoDispatch, will work.  I also changed the way the method is called so that the parameters are more in line with what the route does.  That way, instead of receiving an array as parameters, you actually receive every parameter.