### PR TITLE
Extra route patterns for hexadecimal and uuid v4.

### DIFF
--- a/app/Core/Router.php
+++ b/app/Core/Router.php
@@ -63,7 +63,9 @@ class Router
     public static $patterns = array(
         ':any' => '[^/]+',
         ':num' => '-?[0-9]+',
-        ':all' => '.*'
+        ':all' => '.*',
+        ':hex' => '[[:xdigit:]]+',
+        ':uuidV4' => '\w{8}-\w{4}-\w{4}-\w{4}-\w{12}'
     );
 
     /**


### PR DESCRIPTION
Thought these might be useful. :all is really not that useful in RESTful pattern matching, and digits (:num) is not the only use case.

If you are using mongo you may want to do:
Router::get('users/(:hex)', 'Controllers\user@getOne');
Router::get('users/(:hex)/reset-password', 'Controllers\user@resetPassword');

If you are using uuid v4 for something:
Router::get('users/(:uuidV4)', 'Controllers\user@getOne');
Router::get('users/(:uuidV4)/reset-password', 'Controllers\user@resetPassword');