### PR TITLE
Change typo error on create_key description

### DIFF
--- a/app/Helpers/Data.php
+++ b/app/Helpers/Data.php
@@ -82,7 +82,7 @@ class Data
     }
 
     /**
-     * key - this will generate a 35 character key
+     * key - this will generate a 32 character key
      * @return string
      */
      public static function create_key($length = 32)


### PR DESCRIPTION
create_key default value is 32 not 35