### PR TITLE
Improve hookhelper

### DIFF
--- a/app/Helpers/Hooks.php
+++ b/app/Helpers/Hooks.php
@@ -124,12 +124,11 @@ class Hooks
     {
         if (!isset(self::$hooks[$where])) {
             return false;
-        } else {
-            $theseHooks = explode('|', self::$hooks[$where]);
-            $theseHooks[] = $function;
-            self::$hooks[$where] = implode('|', $theseHooks);
-            return true;
         }
+        $theseHooks = explode('|', self::$hooks[$where]);
+        $theseHooks[] = $function;
+        self::$hooks[$where] = implode('|', $theseHooks);
+        return true;
     }
 
     /**
@@ -168,9 +167,8 @@ class Hooks
             }
 
             return $result;
-        } else {
-            return false;
         }
+        return false;
     }
 
     /**

--- a/app/Helpers/Hooks.php
+++ b/app/Helpers/Hooks.php
@@ -119,11 +119,12 @@ class Hooks
      * @param string $where hook to use
      * @param string $function function to attach to hook
      * @return boolean success with adding, false if $where is not defined.
+     * @throws \Exception Exception when hook $where (location) isn't known (yet)
      */
     public static function addHook($where, $function)
     {
         if (!isset(self::$hooks[$where])) {
-            return false;
+            throw new \Exception('Hook location (' . $where . ') not defined!');
         }
         $theseHooks = explode('|', self::$hooks[$where]);
         $theseHooks[] = $function;
@@ -138,6 +139,7 @@ class Hooks
      * @param  string $args option arguments
      *
      * @return object|false - returns the called function or false if the $where is not found
+     * @throws \Exception Exception when hook $where (location) isn't known (yet)
      */
     public function run($where, $args = '')
     {
@@ -168,7 +170,7 @@ class Hooks
 
             return $result;
         }
-        return false;
+        throw new \Exception('Hook location (' . $where . ') not defined!');
     }
 
     /**

--- a/app/Helpers/Hooks.php
+++ b/app/Helpers/Hooks.php
@@ -118,16 +118,17 @@ class Hooks
      *
      * @param string $where hook to use
      * @param string $function function to attach to hook
+     * @return boolean success with adding, false if $where is not defined.
      */
     public static function addHook($where, $function)
     {
         if (!isset(self::$hooks[$where])) {
-            die("There is no such place ($where) for hooks.");
+            return false;
         } else {
             $theseHooks = explode('|', self::$hooks[$where]);
             $theseHooks[] = $function;
             self::$hooks[$where] = implode('|', $theseHooks);
-
+            return true;
         }
     }
 
@@ -137,7 +138,7 @@ class Hooks
      * @param  string $where Hook to execute
      * @param  string $args option arguments
      *
-     * @return object - returns the called function
+     * @return object|false - returns the called function or false if the $where is not found
      */
     public function run($where, $args = '')
     {
@@ -168,7 +169,7 @@ class Hooks
 
             return $result;
         } else {
-            die("There is no such place ($where) for hooks.");
+            return false;
         }
     }
 


### PR DESCRIPTION
Instead of using die() when the $where is unknown it is now throwing an exception. Should be better, and less error prone.
And also removed unneeded else blocks after returning.