### PR TITLE
Fix template path used by core\view. Added new define for the public folder.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,10 @@
+
+# Framework specific
 system/Core/Config.php
 .DS_Store
+
+# IDE's
+
+## IntelliJ IDEA / PhpStorm
+.idea
+*.iml

--- a/public/index.php
+++ b/public/index.php
@@ -6,14 +6,17 @@
 $smvc = '../app/';
 $system = '../system/';
 $root = '../';
+$public = dirname(__FILE__);
 
 /** Define the absolute paths for configured directories */
 define('SMVC', realpath($smvc).DIRECTORY_SEPARATOR);
 define('SYSTEM', realpath($system).DIRECTORY_SEPARATOR);
+define('PUBLICDIR', $public.DIRECTORY_SEPARATOR);
 
 /** Unset non used variables */
 unset($smvc);
 unset($system);
+unset($public);
 
 /** load composer autoloader */
 if (file_exists($root.'vendor/autoload.php')) {

--- a/system/Core/View.php
+++ b/system/Core/View.php
@@ -59,7 +59,7 @@ class View
     {
         self::sendHeaders();
 
-        require $_SERVER['DOCUMENT_ROOT']."/".DIR."templates/$custom/$path.php";
+        require PUBLICDIR . "templates/$custom/$path.php";
     }
 
     /**


### PR DESCRIPTION
The Core\View.php was using $_SERVER[''] and DIR paths to get to the template path. Wasn't working of coarse.