### PR TITLE
FIxing logger memory issues.

### DIFF
--- a/system/Core/Logger.php
+++ b/system/Core/Logger.php
@@ -136,15 +136,12 @@ class Logger
                 ftruncate($f, 0);
                 fclose($f);
             }
-
-            $content = null;
-        } else {
-            $content = file_get_contents($systempath.self::$errorFile);
         }
 
-        file_put_contents($systempath.self::$errorFile, $logMessage . $content);
+        // Append
+        file_put_contents($systempath.self::$errorFile, $logMessage, FILE_APPEND);
 
-        self::$error = $logMessage . $content;
+        self::$error = $logMessage;
         self::customErrorMsg();
 
         //send email
@@ -177,8 +174,8 @@ class Logger
 
             $content = null;
         } else {
-            $content = file_get_contents($systempath.self::$errorFile);
-            file_put_contents($systempath.self::$errorFile, $logMessage . $content);
+            // Append
+            file_put_contents($systempath.self::$errorFile, $logMessage, FILE_APPEND);
         }
 
         /** send email */


### PR DESCRIPTION
The whole error log was being read into memory which causes a memory limit exceed when the log is too big.

Instead of prepending it is now appending to the file with the APPEND flag on file_put_contents. This will not load the whole file into memory.