### PR TITLE
Fixing memory limit exceed when having a big log file (append)

### DIFF
--- a/app/Core/Logger.php
+++ b/app/Core/Logger.php
@@ -124,13 +124,9 @@ class Logger
                 ftruncate($f, 0);
                 fclose($f);
             }
-
-            $content = null;
-        } else {
-            $content = file_get_contents(self::$errorFile);
         }
 
-        file_put_contents(self::$errorFile, $logMessage . $content);
+        file_put_contents(self::$errorFile, $logMessage, FILE_APPEND);
 
         //send email
         self::sendEmail($logMessage);
@@ -163,11 +159,8 @@ class Logger
                 ftruncate($f, 0);
                 fclose($f);
             }
-
-            $content = null;
         } else {
-            $content = file_get_contents(self::$errorFile);
-            file_put_contents(self::$errorFile, $logMessage . $content);
+            file_put_contents(self::$errorFile, $logMessage, FILE_APPEND);
         }
 
         /** send email */


### PR DESCRIPTION
The whole error log was being read into memory which causes a memory limit exceed when the log is too big.

Instead of prepending it is now appending to the file with the APPEND flag on file_put_contents. This will not load the whole file into memory.

**Warning, will append instead of prepend to the log file!**

(Same as in 3.0 beta pull request for fixing it, but this one is still for the 2.* users.).