### PR TITLE
Refactoring the SVMC's System namespace

### DIFF
--- a/app/Controllers/Demo.php
+++ b/app/Controllers/Demo.php
@@ -1,8 +1,8 @@
 <?php
 namespace App\Controllers;
 
-use Core\View;
-use Core\Controller;
+use Smvc\Core\View;
+use Smvc\Core\Controller;
 
 /*
 *

--- a/app/Controllers/Welcome.php
+++ b/app/Controllers/Welcome.php
@@ -10,8 +10,8 @@
 
 namespace App\Controllers;
 
-use Core\View;
-use Core\Controller;
+use Smvc\Core\View;
+use Smvc\Core\Controller;
 
 /**
  * Sample controller showing a construct and 2 methods and their typical usage.

--- a/app/Core/ClassicRouter.php
+++ b/app/Core/ClassicRouter.php
@@ -9,15 +9,15 @@
 
 namespace App\Core;
 
-use Core\Route;
-use Helpers\Request;
-use Helpers\Url;
-use Helpers\Inflector;
+use Smvc\Core\Route;
+use Smvc\Helpers\Request;
+use Smvc\Helpers\Url;
+use Smvc\Helpers\Inflector;
 
 /**
  * Router class will load requested controller / closure based on url.
  */
-class ClassicRouter extends \Core\Router
+class ClassicRouter extends \Smvc\Core\Router
 {
     // Constructor
     public function __construct()

--- a/app/views/error/404.php
+++ b/app/views/error/404.php
@@ -3,7 +3,7 @@
  * Sample layout
  */
 
-use Core\Error;
+use Smvc\Core\Error;
 
 ?>
 <div class="container content">

--- a/app/views/welcome/subpage.php
+++ b/app/views/welcome/subpage.php
@@ -3,7 +3,7 @@
  * Sample layout
  */
 
-use Core\Language;
+use Smvc\Core\Language;
 
 ?>
 

--- a/app/views/welcome/welcome.php
+++ b/app/views/welcome/welcome.php
@@ -3,7 +3,7 @@
  * Sample layout
  */
 
-use Core\Language;
+use Smvc\Core\Language;
 
 ?>
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "autoload": {
         "psr-4": {
-            "" : "system/",
+            "Smvc\\" : "system/",
             "App\\" : "app/"
         }
     },

--- a/public/index.php
+++ b/public/index.php
@@ -57,7 +57,7 @@ if (defined('ENVIRONMENT')) {
 }
 
 /** initiate config */
-new \Core\Config();
+new \Smvc\Core\Config();
 
 /** load routes */
 require SYSTEM.'Core/routes.php';

--- a/public/templates/default/footer.php
+++ b/public/templates/default/footer.php
@@ -3,9 +3,9 @@
  * Sample layout
  */
 
-use Helpers\Assets;
-use Helpers\Url;
-use Helpers\Hooks;
+use Smvc\Helpers\Assets;
+use Smvc\Helpers\Url;
+use Smvc\Helpers\Hooks;
 
 //initialise hooks
 $hooks = Hooks::get();

--- a/public/templates/default/header.php
+++ b/public/templates/default/header.php
@@ -3,9 +3,9 @@
  * Sample layout
  */
 
-use Helpers\Assets;
-use Helpers\Url;
-use Helpers\Hooks;
+use Smvc\Helpers\Assets;
+use Smvc\Helpers\Url;
+use Smvc\Helpers\Hooks;
 
 //initialise hooks
 $hooks = Hooks::get();

--- a/system/Core/Config.example.php
+++ b/system/Core/Config.example.php
@@ -10,9 +10,9 @@
  * @date updated Sept 19, 2015
  */
 
-namespace Core;
+namespace Smvc\Core;
 
-use Helpers\Session;
+use Smvc\Helpers\Session;
 
 /**
  * Configuration constants and options.
@@ -38,7 +38,7 @@ class Config
          * Set the Application Router.
          */
         // Default Routing
-        define('APPROUTER', '\Core\Router');
+        define('APPROUTER', '\Smvc\Core\Router');
         // Classic Routing
         //define('APPROUTER', '\App\Core\ClassicRouter');
 
@@ -108,8 +108,8 @@ class Config
         /**
          * Turn on custom error handling.
          */
-        set_exception_handler('Core\Logger::ExceptionHandler');
-        set_error_handler('Core\Logger::ErrorHandler');
+        set_exception_handler('Smvc\Core\Logger::ExceptionHandler');
+        set_error_handler('Smvc\Core\Logger::ErrorHandler');
 
         /**
          * Set timezone.

--- a/system/Core/Controller.php
+++ b/system/Core/Controller.php
@@ -8,10 +8,10 @@
  * @date updated Sept 19, 2015
  */
 
-namespace Core;
+namespace Smvc\Core;
 
-use Core\View;
-use Core\Language;
+use Smvc\Core\View;
+use Smvc\Core\Language;
 
 /**
  * Core controller, all other controllers extend this base controller.

--- a/system/Core/Database/DatabaseService.php
+++ b/system/Core/Database/DatabaseService.php
@@ -1,9 +1,9 @@
 <?php
 
 
-namespace Core\Database;
-use Core\Database\Engine\Engine;
-use Core\Database\Engine\MySQLEngine;
+namespace Smvc\Core\Database;
+use Smvc\Core\Database\Engine\Engine;
+use Smvc\Core\Database\Engine\MySQLEngine;
 
 /**
  * Class DatabaseService.

--- a/system/Core/Database/Engine/Engine.php
+++ b/system/Core/Database/Engine/Engine.php
@@ -1,7 +1,7 @@
 <?php
 
 
-namespace Core\Database\Engine;
+namespace Smvc\Core\Database\Engine;
 
 /**
  * Interface Engine

--- a/system/Core/Database/Engine/MySQLEngine.php
+++ b/system/Core/Database/Engine/MySQLEngine.php
@@ -1,7 +1,7 @@
 <?php
 
 
-namespace Core\Database\Engine;
+namespace Smvc\Core\Database\Engine;
 
 
 class MySQLEngine extends \PDO implements Engine

--- a/system/Core/Database/EngineFactory.php
+++ b/system/Core/Database/EngineFactory.php
@@ -1,10 +1,10 @@
 <?php
 
 
-namespace Core\Database;
+namespace Smvc\Core\Database;
 
 
-use Core\Database\Engine\Engine;
+use Smvc\Core\Database\Engine\Engine;
 
 abstract class EngineFactory
 {

--- a/system/Core/Database/Entity.php
+++ b/system/Core/Database/Entity.php
@@ -1,7 +1,7 @@
 <?php
 
 
-namespace Core\Database;
+namespace Smvc\Core\Database;
 
 /**
  * Class Entity, can be extended with your database entities

--- a/system/Core/Error.php
+++ b/system/Core/Error.php
@@ -8,10 +8,10 @@
  * @date updated Sept 19, 2015
  */
 
-namespace Core;
+namespace Smvc\Core;
 
-use Core\Controller;
-use Core\View;
+use Smvc\Core\Controller;
+use Smvc\Core\View;
 
 /**
  * Error class to generate 404 pages.

--- a/system/Core/Language.php
+++ b/system/Core/Language.php
@@ -8,9 +8,9 @@
  * @date updated Sept 19, 2015
  */
 
-namespace Core;
+namespace Smvc\Core;
 
-use Core\Error;
+use Smvc\Core\Error;
 
 /**
  * Language class to load the requested language file.

--- a/system/Core/Logger.php
+++ b/system/Core/Logger.php
@@ -8,9 +8,9 @@
  * @date updated Sept 19, 2015
  */
 
-namespace Core;
+namespace Smvc\Core;
 
-use Helpers\PhpMailer\Mail;
+use Smvc\Helpers\PhpMailer\Mail;
 
 /**
  * Record and email/display errors or a custom error message.

--- a/system/Core/Model.php
+++ b/system/Core/Model.php
@@ -8,9 +8,9 @@
  * @date updated Sept 19, 2015
  */
 
-namespace Core;
+namespace Smvc\Core;
 
-use Helpers\Database;
+use Smvc\Helpers\Database;
 
 /**
  * Base model class all other models will extend from this base.

--- a/system/Core/Route.php
+++ b/system/Core/Route.php
@@ -7,7 +7,7 @@
  * @date December 11th, 2015
  */
 
-namespace Core;
+namespace Smvc\Core;
 
 /**
  * The Route class is responsible for routing an HTTP request to an assigned callback function.

--- a/system/Core/Router.php
+++ b/system/Core/Router.php
@@ -7,12 +7,12 @@
  * @date December 11th, 2015
  */
 
-namespace Core;
+namespace Smvc\Core;
 
-use Core\Route;
-use Helpers\Request;
-use Helpers\Url;
-use Helpers\Inflector;
+use Smvc\Core\Route;
+use Smvc\Helpers\Request;
+use Smvc\Helpers\Url;
+use Smvc\Helpers\Inflector;
 
 /**
  * Router class will load requested controller / closure based on url.

--- a/system/Core/Service.php
+++ b/system/Core/Service.php
@@ -7,9 +7,9 @@
  * @date December 13, 2015
  */
 
-namespace Core;
+namespace Smvc\Core;
 
-use Helpers\Database;
+use Smvc\Helpers\Database;
 
 /**
  * Abstract Class Service, Your service classes need to extend this abstract class

--- a/system/Core/View.php
+++ b/system/Core/View.php
@@ -8,7 +8,7 @@
  * @date updated Sept 19, 2015
  */
 
-namespace Core;
+namespace Smvc\Core;
 
 /**
  * View class to load template and views files.

--- a/system/Core/routes.php
+++ b/system/Core/routes.php
@@ -8,8 +8,8 @@
  */
 
 /** Create alias for Router. */
-use Core\Router;
-use Helpers\Hooks;
+use Smvc\Core\Router;
+use Smvc\Helpers\Hooks;
 
 /** Get the Router instance. */
 $router = Router::getInstance();

--- a/system/Helpers/Arr.php
+++ b/system/Helpers/Arr.php
@@ -7,7 +7,7 @@
  * @date updated Sept 19, 2015
  */
 
-namespace Helpers;
+namespace Smvc\Helpers;
 
 /**
  * Collection of array methods.

--- a/system/Helpers/Assets.php
+++ b/system/Helpers/Assets.php
@@ -1,5 +1,5 @@
 <?php
-namespace Helpers;
+namespace Smvc\Helpers;
 
 /**
  * Assets static helper
@@ -10,8 +10,8 @@ namespace Helpers;
  * @date May 18 2015
  */
 
-use Helpers\Url;
-use Helpers\JsMin;
+use Smvc\Helpers\Url;
+use Smvc\Helpers\JsMin;
 
 class Assets
 {

--- a/system/Helpers/Csrf.php
+++ b/system/Helpers/Csrf.php
@@ -7,9 +7,9 @@
  * @date updated Sept 19, 2015
  */
 
-namespace Helpers;
+namespace Smvc\Helpers;
 
-use Helpers\Session;
+use Smvc\Helpers\Session;
 
 /**
  * Instructions:

--- a/system/Helpers/Data.php
+++ b/system/Helpers/Data.php
@@ -8,7 +8,7 @@
  * @date updated Sept 19, 2015
  */
 
-namespace Helpers;
+namespace Smvc\Helpers;
 
 /**
  * Common data lookup methods.

--- a/system/Helpers/Database.php
+++ b/system/Helpers/Database.php
@@ -8,7 +8,7 @@
  * @date updated Sept 19, 2015
  */
 
-namespace Helpers;
+namespace Smvc\Helpers;
 
 use PDO;
 

--- a/system/Helpers/Date.php
+++ b/system/Helpers/Date.php
@@ -8,7 +8,7 @@
  * @date updated Sept 19, 2015
  */
 
-namespace Helpers;
+namespace Smvc\Helpers;
 
 /**
  * collection of methods for working with dates.

--- a/system/Helpers/Document.php
+++ b/system/Helpers/Document.php
@@ -8,7 +8,7 @@
  * @date updated Sept 19, 2015
  */
 
-namespace Helpers;
+namespace Smvc\Helpers;
 
 /**
  * Collection of methods for working with documents.

--- a/system/Helpers/Form.php
+++ b/system/Helpers/Form.php
@@ -8,7 +8,7 @@
  * @date updated Sept 19, 2015
  */
 
-namespace Helpers;
+namespace Smvc\Helpers;
 
 /**
  * Create form elements quickly.

--- a/system/Helpers/Ftp.php
+++ b/system/Helpers/Ftp.php
@@ -8,7 +8,7 @@
  * @date updated Sept 19, 2015
  */
 
-namespace Helpers;
+namespace Smvc\Helpers;
 
 /**
  * Interact with remote FTP Server.

--- a/system/Helpers/GeoCode.php
+++ b/system/Helpers/GeoCode.php
@@ -7,7 +7,7 @@
  * @date April 27, 2015
  * @date updated Sept 19, 2015
  */
-namespace Helpers;
+namespace Smvc\Helpers;
 
 /**
  * Collection of methods for working with Google's GeoCoder.

--- a/system/Helpers/Hooks.php
+++ b/system/Helpers/Hooks.php
@@ -7,7 +7,7 @@
  * @date updated Sept 19, 2015
  */
 
-namespace Helpers;
+namespace Smvc\Helpers;
 
 /**
  * Hooks allow code to be injected into various parts of the framework.

--- a/system/Helpers/Inflector.php
+++ b/system/Helpers/Inflector.php
@@ -7,9 +7,9 @@
  * @date Dec 14, 2015
  */
 
-namespace Helpers;
+namespace Smvc\Helpers;
 
- 
+
 class Inflector extends \Doctrine\Common\Inflector\Inflector
 {
 }

--- a/system/Helpers/JsMin.php
+++ b/system/Helpers/JsMin.php
@@ -1,5 +1,5 @@
 <?php
-namespace Helpers;
+namespace Smvc\Helpers;
 
 /**
  * JSMin.php - modified PHP implementation of Douglas Crockford's JSMin.

--- a/system/Helpers/Number.php
+++ b/system/Helpers/Number.php
@@ -8,7 +8,7 @@
  * @date updated Sept 19, 2015
  */
 
-namespace Helpers;
+namespace Smvc\Helpers;
 
 /**
  * Contains methods for converting number formats and getting a percentage.

--- a/system/Helpers/Paginator.php
+++ b/system/Helpers/Paginator.php
@@ -7,7 +7,7 @@
  * @date updated Sept 19, 2015
  */
 
-namespace Helpers;
+namespace Smvc\Helpers;
 
 /**
  * Split records into multiple pages.

--- a/system/Helpers/Password.php
+++ b/system/Helpers/Password.php
@@ -1,5 +1,5 @@
 <?php
-namespace Helpers;
+namespace Smvc\Helpers;
 
 class Password
 {

--- a/system/Helpers/PhpMailer/Exception.php
+++ b/system/Helpers/PhpMailer/Exception.php
@@ -5,7 +5,7 @@
  * @date May 18 2015
  */
 
-namespace Helpers\PhpMailer;
+namespace Smvc\Helpers\PhpMailer;
 
 /**
  * Exceptions for PHPMailer

--- a/system/Helpers/PhpMailer/Mail.php
+++ b/system/Helpers/PhpMailer/Mail.php
@@ -8,7 +8,7 @@
  * @date updated Sept 19, 2015
  */
 
-namespace Helpers\PhpMailer;
+namespace Smvc\Helpers\PhpMailer;
 
 /**
  * Custom class for PHPMailer to uniform sending emails.

--- a/system/Helpers/PhpMailer/PhpMailer.php
+++ b/system/Helpers/PhpMailer/PhpMailer.php
@@ -17,7 +17,7 @@
  * FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-namespace Helpers\PhpMailer;
+namespace Smvc\Helpers\PhpMailer;
 
 require('Smtp.php');
 require('Pop3.php');

--- a/system/Helpers/PhpMailer/Pop3.php
+++ b/system/Helpers/PhpMailer/Pop3.php
@@ -17,7 +17,7 @@
  * FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-namespace Helpers\PhpMailer;
+namespace Smvc\Helpers\PhpMailer;
 
 /**
  * PHPMailer POP-Before-SMTP Authentication Class.

--- a/system/Helpers/PhpMailer/Smtp.php
+++ b/system/Helpers/PhpMailer/Smtp.php
@@ -17,7 +17,7 @@
  * FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-namespace Helpers\PhpMailer;
+namespace Smvc\Helpers\PhpMailer;
 
 /**
  * PHPMailer RFC821 SMTP email transport class.

--- a/system/Helpers/RainCaptcha.php
+++ b/system/Helpers/RainCaptcha.php
@@ -7,7 +7,7 @@
 ** This code is in the public domain.
 */
 
-namespace Helpers;
+namespace Smvc\Helpers;
 
 /**
  * RainCaptcha: Anti-spam protection for your website.

--- a/system/Helpers/Request.php
+++ b/system/Helpers/Request.php
@@ -6,7 +6,7 @@
  * @date updated Sept 19, 2015
  */
 
-namespace Helpers;
+namespace Smvc\Helpers;
 
 /**
  * It contains the request information and provide methods to fetch request body.

--- a/system/Helpers/ReservedWords.php
+++ b/system/Helpers/ReservedWords.php
@@ -1,5 +1,5 @@
 <?php
-namespace Helpers;
+namespace Smvc\Helpers;
 
 class ReservedWords
 {

--- a/system/Helpers/Session.php
+++ b/system/Helpers/Session.php
@@ -8,7 +8,7 @@
  * @date updated Sept 19, 2015
  */
 
-namespace Helpers;
+namespace Smvc\Helpers;
 
 /**
  * Prefix sessions with useful methods.

--- a/system/Helpers/SimpleCurl.php
+++ b/system/Helpers/SimpleCurl.php
@@ -8,7 +8,7 @@
 * @date updated Sept 19, 2015
 */
 
-namespace Helpers;
+namespace Smvc\Helpers;
 
 /**
  * Sets some default functions and settings.

--- a/system/Helpers/TableBuilder.php
+++ b/system/Helpers/TableBuilder.php
@@ -8,10 +8,10 @@
  * @date updated Sept 19, 2015
  */
 
-namespace Helpers;
+namespace Smvc\Helpers;
 
 use PDO;
-use Helpers\Database;
+use Smvc\Helpers\Database;
 
 /**
  * Table builder class for SimpleMVCFramework.

--- a/system/Helpers/Tags.php
+++ b/system/Helpers/Tags.php
@@ -7,9 +7,9 @@
  * @date Sept 19, 2015
  */
 
-namespace Helpers;
+namespace Smvc\Helpers;
 
-use Helpers\Database;
+use Smvc\Helpers\Database;
 
 /**
  * Collection of useful methods.

--- a/system/Helpers/Url.php
+++ b/system/Helpers/Url.php
@@ -8,9 +8,9 @@
  * @date updated Sept 19, 2015
  */
 
-namespace Helpers;
+namespace Smvc\Helpers;
 
-use Helpers\Session;
+use Smvc\Helpers\Session;
 
 /**
  * Collection of methods for working with urls.


### PR DESCRIPTION
The components of SMVC's System directory are now enclosed in the namespace **\Smvc**

For example, we have now:

```
\Smvc\Core\Controller
\Smvc\Helpers\Database
``'