### PR TITLE
Refactor Database engine/services and PhpMailer to use the new config structure

### DIFF
--- a/app/Config/config.php
+++ b/app/Config/config.php
@@ -20,3 +20,21 @@ Config::set('emailer', array(
     'mailer_smtp_pass'     => '',    // Only when using SMTPAuth
     'mailer_smtp_authtype' => ''     // Options are LOGIN (default), PLAIN, NTLM, CRAM-MD5. Blank when not use SMTPAuth.
 ));
+
+
+/**
+ * Database configurations
+ *
+ * By default, the 'default' connection will be used when no connection name is given to the engine factory.
+ */
+Config::set('database', array(
+    'default' => array(
+        'engine' => 'mysql',
+        'config' => array(
+            'host' => 'localhost',
+            'database' => 'dbname',
+            'user' => 'root',
+            'pass' => 'password'
+        )
+    )
+));

--- a/app/Config/constants.php
+++ b/app/Config/constants.php
@@ -29,33 +29,6 @@ define('TEMPLATE', 'default');
  */
 define('LANGUAGE_CODE', 'en');
 
-//database details ONLY NEEDED IF USING A DATABASE
-
-/**
- * Database engine default is mysql.
- */
-define('DB_TYPE', 'mysql');
-
-/**
- * Database host default is localhost.
- */
-define('DB_HOST', 'localhost');
-
-/**
- * Database name.
- */
-define('DB_NAME', 'dbname');
-
-/**
- * Database username.
- */
-define('DB_USER', 'root');
-
-/**
- * Database password.
- */
-define('DB_PASS', 'password');
-
 /**
  * PREFER to be used in database calls default is smvc_
  */
@@ -75,21 +48,3 @@ define('SITETITLE', 'V3.0');
  * Optional set a site email address.
  */
 // define('SITEEMAIL', 'email@domain.com');
-
-/**
- * Email (PHPMailer) configuration
- */
-define('MAILER_CHARSET', 'iso-8859-1');
-define('MAILER_FROM_NAME', 'SMVC Website');
-define('MAILER_FROM_EMAIL', 'smvc@localhost');
-define('MAILER_MAILER', 'mail'); // Could be 'mail', 'sendmail' or 'smtp'
-
-/** Only when using smtp as mailer: */
-define('MAILER_SMTP_HOST', 'localhost');
-define('MAILER_SMTP_PORT', 25);
-define('MAILER_SMTP_SECURE', ''); // Options: '', 'ssl' or 'tls'
-define('MAILER_SMTP_AUTH', false); // Use SMTPAuth, (false or true)
-define('MAILER_SMTP_USER', ''); // Only when using SMTPAuth
-define('MAILER_SMTP_PASS', ''); // Only when using SMTPAuth
-define('MAILER_SMTP_AUTHTYPE', ''); // Options are LOGIN (default), PLAIN, NTLM, CRAM-MD5. Blank when not use SMTPAuth.
-

--- a/system/Database/Engine/MySQLEngine.php
+++ b/system/Database/Engine/MySQLEngine.php
@@ -43,7 +43,7 @@ class MySQLEngine extends \PDO implements Engine
 
     /**
      * Get native connection. Could be \PDO
-     * @return mixed|\PDO
+     * @return \PDO
      */
     public function getConnection()
     {

--- a/system/Database/Service/MySQLService.php
+++ b/system/Database/Service/MySQLService.php
@@ -27,9 +27,9 @@ class MySQLService extends DatabaseService implements Service
     {
         if ($engine === null)
         {
-            $engine = EngineFactory::getEngine(EngineFactory::DRIVER_MYSQL);
+            $engine = EngineFactory::getEngine();
         }
-
+        
         $this->driver = EngineFactory::DRIVER_MYSQL;
 
         parent::__construct($engine);

--- a/system/Helpers/PhpMailer.php
+++ b/system/Helpers/PhpMailer.php
@@ -10,6 +10,7 @@
  */
 
 namespace Smvc\Helpers;
+use Smvc\Core\Config;
 
 
 /**
@@ -23,21 +24,23 @@ class PhpMailer extends \PHPMailer
     {
         parent::__construct();
 
+        $config = Config::get('emailer');
+
         // Set all config in myself
-        $this->CharSet = MAILER_CHARSET;
-        $this->FromName = MAILER_FROM_NAME;
-        $this->From = MAILER_FROM_EMAIL;
-        $this->Mailer = MAILER_MAILER;
+        $this->CharSet = $config['mailer_charset'];
+        $this->FromName = $config['mailer_from_name'];
+        $this->From = $config['mailer_from_email'];
+        $this->Mailer = $config['mailer_mailer'];
 
         if ($this->Mailer === 'smtp')
         {
-            $this->Host = MAILER_SMTP_HOST;
-            $this->Port = MAILER_SMTP_PORT;
-            $this->SMTPSecure = MAILER_SMTP_SECURE;
-            $this->SMTPAuth = MAILER_SMTP_AUTH;
-            $this->Username = MAILER_SMTP_USER;
-            $this->Password = MAILER_SMTP_PASS;
-            $this->AuthType = MAILER_SMTP_AUTHTYPE;
+            $this->Host = $config['mailer_smtp_host'];
+            $this->Port = $config['mailer_smtp_port'];
+            $this->SMTPSecure = $config['mailer_smtp_secure'];
+            $this->SMTPAuth = $config['mailer_smtp_auth'];
+            $this->Username = $config['mailer_smtp_user'];
+            $this->Password = $config['mailer_smtp_pass'];
+            $this->AuthType = $config['mailer_smtp_authtype'];
         }
     }
 }


### PR DESCRIPTION
Refactoring the use of database engine factory, service and the PhpMailer extending helper to use the new configuration structure.

New use on creating a database connection. You can have multiple connection configs for database connection.

The config structure will be like:
```php
Config::set('database', array(
    'default' => array(
        'engine' => 'mysql',
        'config' => array(
            'host' => 'localhost',
            'database' => 'dbname',
            'user' => 'root',
            'pass' => 'password'
        )
    )
));
```
The default will be used when not giving the name when creating engine with the factory.

### When you want 2 connections, you could use it like this:

Config:
```php
Config::set('database', array(
    'default' => array(
        'engine' => 'mysql',
        'config' => array(
            'host' => 'localhost',
            'database' => 'dbname',
            'user' => 'root',
            'pass' => 'password'
        )
    ),
    'other' => array(
        'engine' => 'mysql',
        'config' => array(
            'host' => 'remote.address',
            'database' => 'dbname',
            'user' => 'root',
            'pass' => 'password'
        )
    )
));
```


And you could use it like this:
```php
$engine_default = \Smvc\Database\EngineFactory::getEngine();
$engine_other = \Smvc\Database\EngineFactory::getEngine('other');
```
