### PR TITLE
The prefixing 'SELECT ' in the query (for mysql engine) can still be in the query.

### DIFF
--- a/app/Controllers/Demo.php
+++ b/app/Controllers/Demo.php
@@ -52,6 +52,10 @@ class Demo extends Controller
 
         // Use it without the Services:
         $engine = EngineFactory::getEngine();
+        $result_plain = $engine->select('SELECT * FROM '.PREFIX.'car');
+        var_dump($result_plain);
+
+        // Using the select and prefix the SELECT in the sql is optional for the MySQL Engine!
         $result_plain = $engine->select('* FROM '.PREFIX.'car');
         var_dump($result_plain);
 

--- a/system/Database/Engine/MySQLEngine.php
+++ b/system/Database/Engine/MySQLEngine.php
@@ -62,7 +62,10 @@ class MySQLEngine extends \PDO implements Engine
      */
     public function select($sql, $array = array(), $fetchMode = \PDO::FETCH_OBJ, $class = null)
     {
-        $stmt = $this->prepare("SELECT " . $sql);
+        if (strtolower(substr($sql, 0, 7)) !== 'select ') {
+            $sql = "SELECT " . $sql;
+        }
+        $stmt = $this->prepare($sql);
         foreach ($array as $key => $value) {
             if (is_int($value)) {
                 $stmt->bindValue("$key", $value, \PDO::PARAM_INT);


### PR DESCRIPTION
Now you can do it with or without:

```php
$result_plain = $engine->select('SELECT * FROM '.PREFIX.'car');
$result_plain = $engine->select('* FROM '.PREFIX.'car');
```

Remeber, we need to move the configs and add .dist.php after it, and add it to the gitignore when stable. So we could update the git without having to clear our personal configs each time.