### PR TITLE
3.0 - Upgrade Bootstrap to 3.3.6

### DIFF
--- a/public/templates/default/footer.php
+++ b/public/templates/default/footer.php
@@ -17,7 +17,7 @@ $hooks = Hooks::get();
 <?php
 Assets::js(array(
 	Url::templatePath() . 'js/jquery.js',
-	'https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js'
+	'https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js'
 ));
 
 //hook for plugging in javascript

--- a/public/templates/default/header.php
+++ b/public/templates/default/header.php
@@ -24,7 +24,7 @@ $hooks = Hooks::get();
 	<!-- CSS -->
 	<?php
 	Assets::css(array(
-		'https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css',
+		'https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css',
 		Url::templatePath() . 'css/style.css',
 	));
 


### PR DESCRIPTION
For more information see http://blog.getbootstrap.com/2015/11/24/bootstrap-3-3-6-released/