### PR TITLE
Consolidate the Routing's error checking and optimize the Standard an…

### DIFF
--- a/app/Core/ClassicRouter.php
+++ b/app/Core/ClassicRouter.php
@@ -145,25 +145,13 @@ class ClassicRouter extends \Smvc\Core\Router
         // Get the normalized Method
         $method = !empty($parts) ? array_shift($parts) : DEFAULT_METHOD;
 
-        // Get the Controller's className.
+        // Get the Controller's class name.
         $controller = str_replace(array('//', '/'), '\\', 'App/'.$basePath.$directory.$controller);
 
-        // Controller's Methods starting with '_' are not allowed also to be called on Router.
-        if (($method[0] === '_') || !class_exists($controller)) {
-            return false;
-        }
+        // Get the parameters, if any.
+        $params = !empty($parts) ? $parts : array();
 
-        // Initialize the Controller
-        $controller = new $controller();
-
-        // Check for a valid public Controller's Method.
-        if (! in_array(strtolower($method), array_map('strtolower', get_class_methods($controller)))) {
-            return false;
-        }
-
-        // Execute the current Controller's Method with the given arguments.
-        call_user_func_array(array($controller, $method), !empty($parts) ? $parts : array());
-
-        return true;
+        // Invoke the Controller's Method with the given arguments.
+        return $this->invokeController($controller, $method, $params);
     }
 }

--- a/system/Core/Router.php
+++ b/system/Core/Router.php
@@ -128,6 +128,34 @@ class Router
     }
 
     /**
+     * Invoke the Controller's Method with its associated parameters.
+     *
+     * @param  string $controller
+     * @param  string $method
+     * @param  array  $params array of matched parameters
+     */
+    protected function invokeController($controller, $method, $params)
+    {
+        // Check first if the Controller exists.
+        if (!class_exists($controller)) {
+            return false;
+        }
+
+        // Initialize the Controller.
+        $controller = new $controller();
+
+        // Controller's Methods starting with '_' are not allowed also to be called on the Router.
+        if (($method[0] === '_') || ! in_array(strtolower($method), array_map('strtolower', get_class_methods($controller)))) {
+            return false;
+        }
+
+        // Execute the Controller's Method with the given arguments.
+        call_user_func_array(array($controller, $method), $params);
+
+        return true;
+    }
+
+    /**
      * Invoke the callback with its associated parameters.
      *
      * @param  object $callback
@@ -138,7 +166,9 @@ class Router
     {
         if (is_object($callback)) {
             // Call the Closure.
-            return call_user_func_array($callback, $params);
+            call_user_func_array($callback, $params);
+
+            return true;
         }
 
         // Call the object Controller and its Method.
@@ -147,11 +177,8 @@ class Router
         $controller = $segments[0];
         $method     = $segments[1];
 
-        // Initialize the Controller
-        $controller = new $controller();
-
-        // Execute the Controller's Method with the given arguments.
-        return call_user_func_array(array($controller, $method), $params);
+        // Invoke the Controller's Method with the given arguments.
+        return $this->invokeController($controller, $method, $params);
     }
 
     public function dispatch()

--- a/system/Core/Router.php
+++ b/system/Core/Router.php
@@ -130,9 +130,9 @@ class Router
     /**
      * Invoke the Controller's Method with its associated parameters.
      *
-     * @param  string $controller
-     * @param  string $method
-     * @param  array  $params array of matched parameters
+     * @param  string $controller to be instantiated
+     * @param  string $method method to be invoked
+     * @param  array  $params parameters passed to method
      */
     protected function invokeController($controller, $method, $params)
     {


### PR DESCRIPTION
…d Classic Routers.

This pull request introduce a better error checking in the Routing on both Standard and Classic Router; now, for a Controller's Method to be executed, it should respect those conditions:

- Of course, its Controller to exists, as in accessible on Composer paths.
- To be defined in the current Controller, not in one of Class parents.
- To be a public function.
- Its name to not start with the char '_' (underline)

Rationale: 

In this way, we can avoid the access via Routing of the Methods defined in the Controller's parents and to "mask" some public method on the current Controller, via starting with char '_' (in the CodeIgniter style), for permitting to have additional public methods defined for diverse uses. 

In other hand, the Routing structure is better optimized and behave slightly faster.