### PR TITLE
Introducing the Modules Management and their bootstrapping

### DIFF
--- a/app/Config/bootstrap.php
+++ b/app/Config/bootstrap.php
@@ -7,8 +7,9 @@
  * @date December 15th, 2015
  */
 
-use Smvc\Helpers\Session;
+use Smvc\Core\Config;
 use Smvc\Core\Router;
+use Smvc\Helpers\Session;
 use Smvc\Modules\Manager as Modules;
 
 /**
@@ -30,7 +31,7 @@ set_error_handler('Smvc\Core\Logger::ErrorHandler');
 /**
  * Set timezone.
  */
-date_default_timezone_set('Europe/Rome');
+date_default_timezone_set(Config::get('timezone'));
 
 /**
  * Start sessions.

--- a/app/Config/bootstrap.php
+++ b/app/Config/bootstrap.php
@@ -44,7 +44,7 @@ $router = Router::getInstance();
 require dirname(__FILE__).'/routes.php';
 
 /** bootstrap the active modules (and their associated routes) */
-Modules::boostrap();
+Modules::bootstrap();
 
 /** Execute matched routes. */
 $router->dispatch();

--- a/app/Config/bootstrap.php
+++ b/app/Config/bootstrap.php
@@ -8,6 +8,8 @@
  */
 
 use Smvc\Helpers\Session;
+use Smvc\Core\Router;
+use Smvc\Modules\Manager as Modules;
 
 /**
  * Turn on output buffering.
@@ -35,5 +37,14 @@ date_default_timezone_set('Europe/Rome');
  */
 Session::init();
 
+/** Get the Router instance. */
+$router = Router::getInstance();
+
 /** load routes */
 require dirname(__FILE__).'/routes.php';
+
+/** bootstrap the active modules (and their associated routes) */
+Modules::boostrap();
+
+/** Execute matched routes. */
+$router->dispatch();

--- a/app/Config/config.php
+++ b/app/Config/config.php
@@ -10,6 +10,11 @@
 use Smvc\Core\Config;
 
 /**
+ * Set the Framework's timezone.
+ */
+Config::set('timezone', 'Europe/Rome');
+
+/**
  * All known Languages
  */
 Config::set('languages', array(

--- a/app/Config/config.php
+++ b/app/Config/config.php
@@ -66,5 +66,6 @@ Config::set('database', array(
  * Active Modules
  */
 Config::set('modules', array(
-
+    //'Blog',
+    //'Page'
 ));

--- a/app/Config/config.php
+++ b/app/Config/config.php
@@ -61,3 +61,10 @@ Config::set('database', array(
         )
     )
 ));
+
+/**
+ * Active Modules
+ */
+Config::set('modules', array(
+
+));

--- a/app/Config/routes.php
+++ b/app/Config/routes.php
@@ -11,9 +11,6 @@
 use Smvc\Core\Router;
 use Smvc\Helpers\Hooks;
 
-/** Get the Router instance. */
-$router = Router::getInstance();
-
 /** Define static routes. */
 
 // Default Routing
@@ -40,5 +37,3 @@ $hooks->run('routes');
 /** If no route found. */
 Router::error('\App\Controllers\Error@error404');
 
-/** Execute matched routes. */
-$router->dispatch();

--- a/scripts/makelinks.php
+++ b/scripts/makelinks.php
@@ -1,0 +1,238 @@
+#!/usr/bin/env php
+<?php
+
+define("DS", DIRECTORY_SEPARATOR);
+
+define("BASEPATH", dirname(dirname(__FILE__)) .DS);
+
+define("WEBROOT", BASEPATH.'public'.DS);
+
+// Init the Composer autoloading.
+require BASEPATH .'vendor/autoload.php';
+
+//
+use Smvc\Helpers\Inflector;
+
+
+//
+function mkdirs($dir, $mode = 0777, $recursive = true) {
+  if( is_null($dir) || $dir === "" ) {
+    return false;
+  }
+
+  if( is_dir($dir) || $dir === "/" ) {
+    return true;
+  }
+
+  if( mkdirs(dirname($dir), $mode, $recursive) ) {
+    return mkdir($dir, $mode);
+  }
+
+  return false;
+}
+//
+function phpGrep($path) {
+    $ret = array();
+
+    $fp = opendir($path);
+
+    while($f = readdir($fp)) {
+        if( preg_match("#^\.+$#", $f) ) continue; // ignore symbolic links
+
+        $file_full_path = $path.DS.$f;
+
+        if(is_dir($file_full_path)) {
+            $ret = array_unique(array_merge($ret, phpGrep($file_full_path)));
+        }
+        else {
+            $ret[] = $file_full_path;
+        }
+    }
+
+    return $ret;
+}
+
+function makeSymlink($path) {
+    if(preg_match('#^assets/(.*)$#i', $path, $matches)) {
+        $filePath = 'assets/'.$matches[1];
+    }
+    else if(preg_match('#^app/(templates|modules)/(.+)/assets/(.*)$#i', $path, $matches)) {
+        // We need to classify the second match string (the Module/Template name).
+        $module = Inflector::tableize($matches[2]);
+
+        $filePath = $matches[1].'/'.$module.'/assets/'.$matches[3];
+    }
+
+    //
+    $linkPath = WEBROOT.$filePath;
+
+    $dirPath = WEBROOT.dirname($filePath);
+
+    $targetPath = str_repeat('../', count(explode('/', dirname($path))) + 1).$path;
+
+    // Check if our target is an already existing symlink or directory, with cleanup.
+    if(is_link($linkPath)) {
+        $target = readlink($linkPath);
+
+        $target = str_replace('../', '', $target);
+
+        if($target == $filePath) {
+            return;
+        }
+
+        unlink($linkPath);
+    }
+    else if(is_dir($linkPath)) {
+        recursiveRemoveDirs($linkPath);
+    }
+
+    mkdirs($dirPath);
+
+    @unlink($linkPath);
+    symlink($targetPath, $linkPath);
+}
+
+function recursiveRemoveDirs($dir)
+{
+    if(! is_dir($dir)) {
+        return;
+    }
+
+    $files = array_diff(scandir($dir), array('..', '.'));
+
+    foreach ($files as $file) {
+        $filePath = $dir.'/'.$file;
+
+        if( is_dir($filePath) ) {
+            recursiveRemoveDirs($filePath);
+        }
+        else {
+            unlink($filePath);
+        }
+    }
+
+    rmdir($dir);
+}
+
+function removeInvalidSymlinks($path)
+{
+    $files = array_diff(scandir($path), array(".", ".."));
+
+    foreach ($files as $file) {
+        $filePath = $path.DS.$file;
+
+        if (is_dir($filePath)) {
+            removeInvalidSymlinks($filePath);
+        }
+        else if(is_link($filePath)) {
+            $target = readlink($filePath);
+
+            $target = BASEPATH.str_replace('../', '', $target);
+
+            if(is_readable(realpath($target))) {
+                continue;
+            }
+
+            unlink($filePath);
+        }
+    }
+}
+
+function removeEmptySubDirs($path)
+{
+    $empty = true;
+
+    foreach (glob($path .DS ."*") as $file) {
+        if (is_dir($file)) {
+            if (! removeEmptySubDirs($file)) $empty = false;
+        }
+        else {
+            $empty = false;
+        }
+    }
+
+    if ($empty) rmdir($path);
+
+    return $empty;
+}
+
+//
+$workPaths = array(
+    'assets',
+);
+
+//
+if(is_dir(BASEPATH .'app'.DS.'Modules')) {
+    $path = str_replace('/', DS, BASEPATH .'app/Modules/*');
+
+    $dirs = glob($path , GLOB_ONLYDIR);
+
+    foreach($dirs as $module) {
+        $workPaths[] = str_replace('/', DS, 'app/Modules/'.$module);
+    }
+}
+
+if(is_dir(BASEPATH .'app'.DS.'Templates')) {
+    $path = str_replace('/', DS, BASEPATH .'app/Templates/*');
+
+    $dirs = glob($path , GLOB_ONLYDIR);
+
+    foreach($dirs as $template) {
+        $workPaths[] = str_replace('/', DS, 'app/Templates/'.$template);
+    }
+}
+
+//
+$options = getopt('', array('path::'));
+
+if(! empty($options['path'])) {
+    $worksPaths = array_map('trim', explode(',', $options['path']));
+}
+
+//
+foreach($workPaths as $workPath) {
+    $searchPath = BASEPATH .$workPath .(($workPath == 'assets') ? '' : '/Assets');
+
+    if(! is_dir($searchPath)) {
+	continue;
+    }
+
+    $results = phpGrep($searchPath);
+
+    if(empty($results)) {
+        continue;
+    }
+
+    foreach($results as $path) {
+        $filePath = str_replace(array(BASEPATH, '//'), array('', '/'), $path);
+
+        switch($fileExt = pathinfo($filePath, PATHINFO_EXTENSION)) {
+            case 'css':
+            case 'js':
+            case 'png':
+            case 'gif':
+            case 'jpg':
+            case 'JPG':
+            case 'ogg':
+            case 'mp3':
+            case 'pdf':
+                makeSymlink($filePath);
+                break;
+            default:
+                break;
+        }
+    }
+}
+
+echo 'Asset Symlinks created, cleaning up... ';
+
+foreach(array('assets', 'modules', 'templates') as $path) {
+    $path = WEBROOT.$path;
+
+    removeInvalidSymlinks($path);
+    removeEmptySubDirs($path);
+}
+
+echo 'Done.'.PHP_EOL;
+
+

--- a/system/Modules/AbstractModule.php
+++ b/system/Modules/AbstractModule.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * AbstractModule - base class for Modules management.
+ *
+ * @author Virgil-Adrian Teaca - virgil@@giulianaeassociati.com
+ * @version 3.0
+ * @date December 16th, 2015
+ */
+
+namespace Smvc\Modules;
+
+
+abstract class AbstractModule
+{
+
+}

--- a/system/Modules/Manager.php
+++ b/system/Modules/Manager.php
@@ -33,7 +33,7 @@ class Manager
                 continue;
             }
 
-            include $filePath;
+            require $filePath;
         }
     }
 }

--- a/system/Modules/Manager.php
+++ b/system/Modules/Manager.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Modules Manager - class responsible to Modules management.
+ *
+ * @author Virgil-Adrian Teaca - virgil@@giulianaeassociati.com
+ * @version 3.0
+ * @date December 16th, 2015
+ */
+
+namespace Smvc\Modules;
+
+use Smvc\Core\Config;
+
+
+class Manager
+{
+    /**
+     * Bootstrap the active Modules.
+     *
+     */
+    public static function bootstrap()
+    {
+        $modules = Config::get('modules');
+
+        if(! $modules) {
+            return;
+        }
+
+        foreach($modules as $module) {
+            $filePath = str_replace('/', DS, APP.'Modules/'.$module.'/Config/bootstrap.php');
+
+            if(!is_readable($filePath)) {
+                continue;
+            }
+
+            include $filePath;
+        }
+    }
+}


### PR DESCRIPTION
This push-request introduce the Modules Management to SMVC 3.0

Right now, the Modules Management execute the bootstrap of active Modules, on the Framework boot stage, permitting to have and use **per Module** configurations. 

The Config entry for the active Modules, from **app/Config/config.php** is in an array of strings, containing the Modules name.

Typically, a file located in Module's **Config** directory, called **bootstrap.php** is executed if exists. For example, for a Module called **Blog**, its bootstrap file is located in:

```
/app/Modules/Blog/Config/bootstrap.php
``` 

The Module's bootstrap files should call the companion files, usually **config.php** and **routes.php**. When new constants, specifically for this Module are defined, they go on **constants.php**

An example content for a typical bootstrap file is:

```php
//require dirname(__FILE__) .'/constants.php';
require dirname(__FILE__) .'/config.php';
require dirname(__FILE__) .'/routes.php';
```

The second stage **config** files content are as usual, similar with those from App Configuration.
