### PR TITLE
 Refactoring some SITE* Constants (SITETITLE and SITEEMAIL)

### DIFF
--- a/app/Config/constants.php
+++ b/app/Config/constants.php
@@ -49,9 +49,9 @@ define('SESSION_PREFIX', 'smvc_');
 /**
  * Optional create a constant for the name of the site.
  */
-define('SITETITLE', 'V3.0');
+define('SITE_TITLE', 'V3.0');
 
 /**
  * Optional set a site email address.
  */
-// define('SITEEMAIL', 'email@domain.com');
+// define('SITE_EMAIL', 'email@domain.com');

--- a/public/templates/default/header.php
+++ b/public/templates/default/header.php
@@ -19,7 +19,7 @@ $hooks = Hooks::get();
 	//hook for plugging in meta tags
 	$hooks->run('meta');
 	?>
-	<title><?php echo $data['title'].' - '.SITETITLE;?></title>
+	<title><?php echo $data['title'].' - '.SITE_TITLE;?></title>
 
 	<!-- CSS -->
 	<?php

--- a/system/Helpers/Tags.php
+++ b/system/Helpers/Tags.php
@@ -60,10 +60,10 @@ class Tags
         $string = str_replace('[year]', date('Y'), $string);
 
         //name of website
-        $string = str_replace('[sitetitle]', SITETITLE, $string);
+        $string = str_replace('[sitetitle]', SITE_TITLE, $string);
 
         //site email address
-        $string = str_replace('[siteemail]', SITEEMAIL, $string);
+        $string = str_replace('[siteemail]', SITE_EMAIL, $string);
 
         //feedburner subscribe form
         $string = preg_replace_callback("(\[feedburner(.*?)])is", function ($matches) {

--- a/system/Logger.php
+++ b/system/Logger.php
@@ -18,7 +18,7 @@ use Smvc\Helpers\PhpMailer as Mailer;
 class Logger
 {
     /**
-    * Determins if error should be emailed to SITEEMAIL defined in app/Core/Config.php.
+    * Determins if error should be emailed to SITE_EMAIL defined in app/Core/Config.php.
     *
     * @var boolean
     */
@@ -192,9 +192,9 @@ class Logger
         if (self::$emailError == true) {
             $mail = new Mailer();
 
-            $mail->setFrom(SITEEMAIL);
-            $mail->addAddress(SITEEMAIL);
-            $mail->subject('New error on '.SITETITLE);
+            $mail->setFrom(SITE_EMAIL);
+            $mail->addAddress(SITE_EMAIL);
+            $mail->subject('New error on '.SITE_TITLE);
             $mail->body($message);
 
             $mail->send();


### PR DESCRIPTION
 Refactoring of Constants. SITETITLE -> SITE_TITLE, SITEEMAIL -> SITE_EMAIL

This one will considerable simplify integration of our code with SMVC3 in future (because those constants we use us, as is, too), and let's be honest! Looks better and more readable! :smile: 

That's all to change in constants and definitions, in my opinion.