### PR TITLE
Update Logger.php to handle \Throwable instead only \Exception 

### DIFF
--- a/app/Core/Logger.php
+++ b/app/Core/Logger.php
@@ -88,12 +88,12 @@ class Logger
     /**
     * New exception.
     *
-    * @param  Exception $exception
+    * @param  Throwable/Exception $exception
     * @param  boolean   $printError show error or not
     * @param  boolean   $clear       clear the errorlog
     * @param  string    $errorFile  file to save to
     */
-    public static function newMessage(\Exception $exception)
+    public static function newMessage($exception)
     {
 
         $message = $exception->getMessage();


### PR DESCRIPTION
Since php7 released, it had introducing Throwable interface for handle Fatal and recoverable errors that threw instances of EngineException,  which did not inherit from Exception.