### PR TITLE
style adjustment for message type

### DIFF
--- a/app/Helpers/Session.php
+++ b/app/Helpers/Session.php
@@ -171,7 +171,7 @@ class Session
     {
         $msg = Session::pull($sessionName);
         if (!empty($msg)) {
-            return "<div class='alert alert-success alert-dismissable'>
+            return "<div class='alert alert-{$sessionName} alert-dismissable'>
                     <button type='button' class='close' data-dismiss='alert' aria-hidden='true'>×</button>
                     <h4><i class='fa fa-check'></i> ".$msg."</h4>
                   </div>";


### PR DESCRIPTION
currently this method only provide alert box with class="alert alert-success alert-dismissable" even the $sessionName is 'info','danger' or 'warning' (base on 4 alert box type on Bootstrap). With little change than this method can show alert box with class="alert alert-info alert-dismissable" , "alert alert-danger alert-dismissable" or "alert alert-warning alert-dismissable" depend on giving $sessionName parameter