### PR TITLE
Make it possible to get services with the manager that belong to one …

### DIFF
--- a/system/Database/Manager.php
+++ b/system/Database/Manager.php
@@ -71,22 +71,28 @@ abstract class Manager
 
     /**
      * Get service instance with class service name
-     * @param string $serviceName the relative namespace class name (relative from App\Services\Database\)
+     * @param string $serviceName the relative or absolute namespace class name (relative from App\Services\Database\)
      * @param Engine|string|null $engine Use the following engine.
      * @return Service|null
      * @throws \Exception
      */
     public static function getService($serviceName, $engine = 'default')
     {
-        $class = 'App\Services\Database\\' . $serviceName;
+        $class = $serviceName;
+
+        // Check if absolute or relative service namespace is given
+        if (substr($serviceName, 0, 3) !== 'App') {
+            // Relative!
+            $class = 'App\Services\Database\\' . $serviceName;
+        }
 
         if ($engine !== null && is_string($engine)) {
             $engine = self::getEngine($engine);
         }
 
-        if (isset(static::$serviceInstances[$serviceName])) {
-            static::$serviceInstances[$serviceName]->setEngine($engine);
-            return static::$serviceInstances[$serviceName];
+        if (isset(static::$serviceInstances[$class])) {
+            static::$serviceInstances[$class]->setEngine($engine);
+            return static::$serviceInstances[$class];
         }
 
         $service = new $class();
@@ -97,7 +103,7 @@ abstract class Manager
 
         $service->setEngine($engine);
 
-        static::$serviceInstances[$serviceName] = $service;
+        static::$serviceInstances[$class] = $service;
 
         return $service;
     }

--- a/system/Database/Manager.php
+++ b/system/Database/Manager.php
@@ -81,7 +81,7 @@ abstract class Manager
         $class = $serviceName;
 
         // Check if absolute or relative service namespace is given
-        if (substr($serviceName, 0, 3) !== 'App') {
+        if (substr($serviceName, 0, 2) !== 'App') {
             // Relative!
             $class = 'App\Services\Database\\' . $serviceName;
         }

--- a/system/Database/Manager.php
+++ b/system/Database/Manager.php
@@ -81,7 +81,7 @@ abstract class Manager
         $className = $serviceName;
 
         // Check if absolute or relative service namespace is given
-        if (substr($serviceName, 0, 2) !== 'App') {
+        if (substr($serviceName, 0, 12) !== 'App\Modules\\') {
             // Relative!
             $className = 'App\Services\Database\\' . $serviceName;
         }

--- a/system/Database/Manager.php
+++ b/system/Database/Manager.php
@@ -78,32 +78,32 @@ abstract class Manager
      */
     public static function getService($serviceName, $engine = 'default')
     {
-        $class = $serviceName;
+        $className = $serviceName;
 
         // Check if absolute or relative service namespace is given
         if (substr($serviceName, 0, 2) !== 'App') {
             // Relative!
-            $class = 'App\Services\Database\\' . $serviceName;
+            $className = 'App\Services\Database\\' . $serviceName;
         }
 
         if ($engine !== null && is_string($engine)) {
             $engine = self::getEngine($engine);
         }
 
-        if (isset(static::$serviceInstances[$class])) {
-            static::$serviceInstances[$class]->setEngine($engine);
-            return static::$serviceInstances[$class];
+        if (isset(static::$serviceInstances[$className])) {
+            static::$serviceInstances[$className]->setEngine($engine);
+            return static::$serviceInstances[$className];
         }
 
-        $service = new $class();
+        $service = new $className();
 
         if (!$service instanceof Service) {
-            throw new \Exception("Class not found '".$class."'!");
+            throw new \Exception("Class not found '".$className."'!");
         }
 
         $service->setEngine($engine);
 
-        static::$serviceInstances[$class] = $service;
+        static::$serviceInstances[$className] = $service;
 
         return $service;
     }


### PR DESCRIPTION
…of the modules. (absolute namespace service name).

Forgot this when making the manager save instances of Services and to use it for getting service instances.

It will now be possible to get services inside of a module by giving an absolute namespace class name to the Manager::getService($serviceName) service name parameter.
It's still possible to get a service with a relative namespace (just as it was).