### PR TITLE
3.0 - Final Phase, stage continued #12

### DIFF
--- a/app/Config/config.php
+++ b/app/Config/config.php
@@ -97,7 +97,8 @@ Config::set('database', array(
             'username'      => 'root',
             'password'      => 'password',
             'fetch_method'  => \PDO::FETCH_OBJ, // Not required, default is OBJ.
-            'charset'       => 'utf8' // Not required, default and recommended is utf8.
+            'charset'       => 'utf8', // Not required, default and recommended is utf8.
+            'compress'      => false   // Changing to true will hugely improve the persormance on remote servers.
         )
     ),
     /** Extra connections can be added here, some examples: */

--- a/app/Modules/Demo/Controllers/Database/Engine.php
+++ b/app/Modules/Demo/Controllers/Database/Engine.php
@@ -25,19 +25,15 @@ class Engine extends BaseController
         //  Demo 2:
         $demo2_example1 = $engine->selectAll("SELECT * FROM " . DB_PREFIX . "car;");
 
-
-
         // Demo 3
         $data = array('make' => 'BMW', 'model' => 'i8', 'costs' => 138000);
+
         $carid = $engine->insert(DB_PREFIX . 'car', $data);
 
         $demo3_example1 = $carid;
 
-
-
         // Demo 4
         $demo4_example1 = $engine->delete(DB_PREFIX . 'car', array('carid' => $carid));
-
 
         $this->set('demo2_example1', $demo2_example1);
         $this->set('demo3_example1', $demo3_example1);
@@ -55,20 +51,19 @@ class Engine extends BaseController
         // Demo 2:
         $demo2_example1 = $engine->selectAll("SELECT * FROM " . DB_PREFIX . "car;");
 
-
         // Demo 3
         $data = array('make' => 'BMW', 'model' => 'i8', 'costs' => 138000);
+
         $carid = $engine->insert(DB_PREFIX . 'car', $data);
 
         $demo3_example1 = $carid;
 
-
         // Demo 4
         $demo4_example1 = $engine->delete(DB_PREFIX . 'car', array('carid' => $carid));
-
 
         $this->set('demo2_example1', $demo2_example1);
         $this->set('demo3_example1', $demo3_example1);
         $this->set('demo4_example1', $demo4_example1);
     }
+    
 }

--- a/app/Modules/Demo/Controllers/Database/Export.php
+++ b/app/Modules/Demo/Controllers/Database/Export.php
@@ -19,4 +19,5 @@ class Export extends BaseController
     {
         $this->title('MySQL Demo Database Export');
     }
+    
 }

--- a/app/Modules/Demo/Controllers/Database/Service.php
+++ b/app/Modules/Demo/Controllers/Database/Service.php
@@ -26,7 +26,6 @@ class Service extends BaseController
         // Demo 2 Make new Car entity
         $demo2 = $carservice->getAll();
 
-
         // Demo 3 Insert new Car
         $car = new Car(); // Create our entity
         $car->make = 'BMW';
@@ -38,10 +37,8 @@ class Service extends BaseController
         // Output our car model again, you will see that the carid is now filled in!
         $demo3 = $car;
 
-
         // Demo 4 delete last car instance
         $demo4 = $carservice->delete($car);
-
 
         $this->set('demo2', $demo2);
         $this->set('demo3', $demo3);
@@ -59,9 +56,9 @@ class Service extends BaseController
         // Demo 2 Make new Car entity
         $demo2 = $carservice->getAll();
 
-
         // Demo 3 Insert new Car
         $car = new Car(); // Create our entity
+
         $car->make = 'BMW';
         $car->model = '1-serie';
         $car->costs = 40000;
@@ -71,13 +68,12 @@ class Service extends BaseController
         // Output our car model again, you will see that the carid is now filled in!
         $demo3 = $car;
 
-
         // Demo 4 delete last car instance
         $demo4 = $carservice->delete($car);
-
 
         $this->set('demo2', $demo2);
         $this->set('demo3', $demo3);
         $this->set('demo4', $demo4);
     }
+    
 }

--- a/app/Modules/Demo/Core/BaseController.php
+++ b/app/Modules/Demo/Core/BaseController.php
@@ -29,16 +29,14 @@ class BaseController extends ThemedController
     {
         parent::__construct();
 
-        $demoMenu = Config::get('demos_menu');
+        $menuItems = Config::get('demos_menu');
 
-        $this->set('topMenuItems', $demoMenu);
+        $this->set('topMenuItems', $menuItems);
         $this->set('dashboardUrl', site_url('demos'));
     }
 
     protected function beforeFlight()
     {
-        $data =& $this->data;
-
         // Leave to parent's method the Flight decisions.
         return parent::beforeFlight();
     }

--- a/system/Database/Engine.php
+++ b/system/Database/Engine.php
@@ -30,7 +30,7 @@ interface Engine
     /**
      * Get the current fetching Method
      */
-    public function getMethod();
+    public function getFetchMethod();
 
     /**
      * Get configuration for instance

--- a/system/Database/Engine.php
+++ b/system/Database/Engine.php
@@ -28,6 +28,11 @@ interface Engine
     public function getDriverCode();
 
     /**
+     * Get the current fetching Method
+     */
+    public function getMethod();
+
+    /**
      * Get configuration for instance
      * @return array
      */

--- a/system/Database/Engine.php
+++ b/system/Database/Engine.php
@@ -99,12 +99,11 @@ interface Engine
      * @param array $data Represents one record, could also have multidimensional arrays inside to insert
      *                    multiple rows in one call. The engine must support this! Check manual!
      * @param bool $transaction
-     * @param bool $multipleInserts Specify to execute multiple inserts.
      * @return bool|int
      *
      * @throws \Exception
      */
-    public function insert($table, $data, $transaction = false, $multipleInserts = false);
+    public function insert($table, $data, $transaction = false);
 
     /**
      * Execute insert query, will automatically build query for you.
@@ -117,7 +116,7 @@ interface Engine
      * @param bool $transaction
      * @return bool|int
      */
-    public function insertAll($table, $data, $transaction = false);
+    public function insertBatch($table, $data, $transaction = false);
 
     /**
      * Execute update query, will automatically build query for you.
@@ -125,24 +124,22 @@ interface Engine
      * @param string $table Table to execute the statement.
      * @param array $data The updated array, will map into an update statement.
      * @param array $where Use key->value like column->value for where mapping.
-     * @param int $limit Limit the update statement, not supported by every engine!
      * @return int|bool
      *
      * @throws \Exception
      */
-    public function update($table, $data, $where, $limit = 1);
+    public function update($table, $data, $where);
 
     /**
      * Execute Delete statement, this will automatically build the query for you.
      *
      * @param string $table Table to execute the statement.
      * @param array $where Use key->value like column->value for where mapping.
-     * @param int $limit Limit the update statement, not supported by every engine!
      * @return bool
      *
      * @throws \Exception
      */
-    public function delete($table, $where, $limit = 1);
+    public function delete($table, $where);
 
     /**
      * Truncate table

--- a/system/Database/Engine/Base.php
+++ b/system/Database/Engine/Base.php
@@ -1,0 +1,494 @@
+<?php
+/**
+ * MySQL Engine.
+ *
+ * @author Tom Valk - tomvalk@lt-box.info
+ * @version 3.0
+ * @date December 19th, 2015
+ */
+
+namespace Nova\Database\Engine;
+
+use Nova\Database\Engine;
+use Nova\Database\Manager;
+
+
+abstract class Base extends \PDO implements Engine
+{
+    /** @var int PDO Fetch method. */
+    private $method = \PDO::FETCH_OBJ;
+
+    /** @var array Config from the user's app config. */
+    private $config;
+
+    /** @var int Counting how much queries have been executed in total. */
+    private $queryCount;
+
+    /**
+     * MySQLEngine constructor.
+     * Please use the Factory to maintain instances of the drivers.
+     *
+     * @param $config array
+     *
+     * @throws \PDOException
+     */
+    public function __construct($dsn, $config = array(), $options = array()) {
+        // Check for valid Config.
+        if (! is_array($config) || ! is_array($options)) {
+            throw new \UnexpectedValueException('Parameter should be an Array');
+        }
+
+        // Will set the default method when provided in the config.
+        if (isset($config['fetch_method'])) {
+            $this->method = $config['fetch_method'];
+        }
+
+        // Reset the query counter
+        $this->queryCount = 0;
+
+        // Store the config in class variable.
+        $this->config = $config;
+
+        //
+        $username = isset($config['username']) ? $config['username'] : '';
+        $password = isset($config['password']) ? $config['password'] : '';
+
+        // Call the PDO constructor.
+        parent::__construct($dsn, $username, $password, $options);
+
+        $this->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+    }
+
+    /**
+     * Get the name of the driver
+     * @return string
+     */
+    abstract public function getDriverName();
+
+    /**
+     * Get driver code, used in config as driver string.
+     * @return string
+     */
+    abstract public function getDriverCode();
+
+    /**
+     * Get configuration for instance
+     * @return array
+     */
+    public function getConfiguration()
+    {
+        return $this->config;
+    }
+
+    /**
+     * Get native connection. Could be \PDO
+     * @return \PDO
+     */
+    public function getConnection()
+    {
+        return $this;
+    }
+
+    /**
+     * Basic execute statement. Only for queries with no binding parameters
+     * This method is not SQL Injection safe! Please remember to don't use this with dynamic content!
+     * This will only return an array or boolean. Depends on your operation and if fetch is on.
+     *
+     * @param $sql
+     * @param $fetch
+     * @return mixed
+     */
+    public function raw($sql, $fetch = false)
+    {
+        $method = $this->method;
+
+        if ($this->method === \PDO::FETCH_CLASS) {
+            // We can't fetch class here to stay conform the interface, make it OBJ for this simple query.
+            $method = \PDO::FETCH_OBJ;
+        }
+
+        $this->queryCount++;
+
+        if (!$fetch) {
+            return $this->exec($sql);
+        }
+
+        $statement = $this->query($sql, $method);
+
+        return $statement->fetchAll();
+    }
+
+    public function rawQuery($sql)
+    {
+        // We can't fetch class here to stay conform the interface, make it OBJ for this simple query.
+        $method = ($this->method !== \PDO::FETCH_CLASS) ? $this->method : \PDO::FETCH_OBJ;
+
+        $this->queryCount++;
+
+        // We don't want to map in memory an entire Billion Records Table, so we return right on a Statement.
+        return $this->query($sql, $method);
+    }
+
+    /**
+     * Execute Select Query, bind values into the $sql query. And give optional method and class for fetch result
+     * The result MUST be an array!
+     *
+     * @param string $sql
+     * @param array $bindParams
+     * @param bool $fetchAll Ask the method to fetch all the records or not.
+     * @param null $method Customized method for fetching, null for engine default or config default.
+     * @param null $class Class for fetching into classes.
+     * @return array|null
+     *
+     * @throws \Exception
+     */
+    public function select($sql, $bindParams = array(), $fetchAll = false, $method = null, $class = null)
+    {
+        // Append select if it isn't appended.
+        if (strtolower(substr($sql, 0, 7)) !== 'select ') {
+            $sql = "SELECT " . $sql;
+        }
+
+        // What method? Use default if no method is given my the call.
+        if ($method === null) {
+            $method = $this->method;
+        }
+
+        // Prepare and get statement from PDO.
+        $stmt = $this->prepare($sql);
+
+        // Bind the key and values (only if given).
+        foreach ($bindParams as $key => $value) {
+            if (is_int($value)) {
+                $stmt->bindValue("$key", $value, \PDO::PARAM_INT);
+            } else {
+                $stmt->bindValue("$key", $value);
+            }
+        }
+
+        // Execute, we should capture the status of the result.
+        $status = $stmt->execute();
+
+        $this->queryCount++;
+
+        // If failed, return now, and don't continue with fetching.
+        if (!$status) {
+            return false;
+        }
+
+        if($fetchAll) {
+            // Continue with fetching all records.
+            if ($method === \PDO::FETCH_CLASS) {
+                if (!$class) {
+                    throw new \Exception("No class is given but you are using the PDO::FETCH_CLASS method!");
+                }
+
+                // Fetch in class
+                $result = $stmt->fetchAll($method, $class);
+            }
+            else {
+                $result = $stmt->fetchAll($method);
+            }
+
+            if (is_array($result) && count($result) > 0) {
+                return $result;
+            }
+
+            return false;
+        }
+
+        // Continue with fetching one record.
+        if ($method === \PDO::FETCH_CLASS) {
+            if (!$class) {
+                throw new \Exception("No class is given but you are using the PDO::FETCH_CLASS method!");
+            }
+
+            // Fetch in class
+            return $stmt->fetch($method, $class);
+        }
+        else {
+            return $stmt->fetch($method);
+        }
+    }
+
+    /**
+     * Convenience method for fetching one record.
+     *
+     * @param string $sql
+     * @param array $bindParams
+     * @param null $method Customized method for fetching, null for engine default or config default.
+     * @param null $class Class for fetching into classes.
+     * @return object|array|null|false
+     * @throws \Exception
+     */
+    public function selectOne($sql, $bindParams = array(), $method = null, $class = null)
+    {
+        return $this->select($sql, $bindParams, false, $method, $class);
+    }
+
+    /**
+     * Convenience method for fetching all records.
+     *
+     * @param string $sql
+     * @param array $bindParams
+     * @param null $method Customized method for fetching, null for engine default or config default.
+     * @param null $class Class for fetching into classes.
+     * @return array|null|false
+     * @throws \Exception
+     */
+    public function selectAll($sql, $bindParams = array(), $method = null, $class = null)
+    {
+        return $this->select($sql, $bindParams, true, $method, $class);
+    }
+
+    /**
+     * Execute insert query, will automatically build query for you.
+     * You can also give an array as $data, this will try to insert each entry in the array.
+     * Not all engine's support this! Check the manual!
+     *
+     * @param string $table Table to execute the insert.
+     * @param array $data Represents one record, could also have multidimensional arrays inside to insert
+     *                    multiple rows in one call. The engine must support this! Check manual!
+     * @param bool $transaction Use PDO Transaction. If one insert will fail we will rollback immediately. Default false.
+     * @return int|bool|array Could be false on error, or one single id inserted, or an array of inserted id's.
+     *
+     * @throws \Exception
+     */
+    public function insert($table, $data, $transaction = false)
+    {
+        $insertId = 0;
+
+        // Check for valid data.
+        if (!is_array($data)) {
+            throw new \Exception("Data to insert must be an array of column -> value.");
+        }
+
+        // Transaction?
+        $status = false;
+
+        if ($transaction) {
+            $status = $this->beginTransaction();
+        }
+
+        // Holding status
+        $failure = false;
+
+        $ids = array();
+
+        // Prepare the parameters.
+        ksort($data);
+
+        $fieldNames = implode(',', array_keys($data));
+        $fieldValues = ':'.implode(', :', array_keys($data));
+
+        $stmt = $this->prepare("INSERT INTO $table ($fieldNames) VALUES ($fieldValues)");
+
+        foreach ($data as $key => $value) {
+            $stmt->bindValue(":$key", $value);
+        }
+
+        // Execute
+        $this->queryCount++;
+
+        if (! $stmt->execute()) {
+            $failure = true;
+        }
+        else {
+            // If no error, capture the last inserted id
+            $insertId = $this->lastInsertId();
+        }
+
+        // Commit when in transaction
+        if (! $failure && $transaction && $status) {
+            $failure = ! $this->commit();
+        }
+
+        // Check for failures
+        if ($failure) {
+            // Ok, rollback when using transactions.
+            if ($transaction) {
+                $this->rollBack();
+            }
+
+            // False on error.
+            return false;
+        }
+
+        return $insertId;
+    }
+
+    /**
+     * Execute insert query, will automatically build query for you.
+     * You can also give an array as $data, this will try to insert each entry in the array.
+     * Not all engine's support this! Check the manual!
+     *
+     * @param string $table Table to execute the insert.
+     * @param array $data Represents one record, could also have multidimensional arrays inside to insert
+     *                    multiple rows in one call. The engine must support this! Check manual!
+     * @param bool $transaction Use PDO Transaction. If one insert will fail we will rollback immediately. Default false.
+     * @return int|bool|array Could be false on error, or one single id inserted, or an array of inserted id's.
+     *
+     * @throws \Exception
+     */
+    abstract public function insertBatch($table, $data, $transaction = false);
+
+    /**
+     * Execute update query, will automatically build query for you.
+     *
+     * @param string $table Table to execute the statement.
+     * @param array $data The updated array, will map into an update statement.
+     * @param array $where Use key->value like column->value for where mapping.
+     * @return int|bool
+     *
+     * @throws \Exception
+     */
+    public function update($table, $data, $where)
+    {
+        // Sort on key
+        ksort($data);
+
+        // Column :bind for auto binding.
+        $fieldDetails = null;
+
+        foreach ($data as $key => $value) {
+            $fieldDetails .= "$key = :field_$key,";
+        }
+
+        $fieldDetails = rtrim($fieldDetails, ',');
+
+        // Where :bind for auto binding
+        $whereDetails = null;
+        $idx = 0;
+
+        foreach ($where as $key => $value) {
+            if ($idx == 0) {
+                $whereDetails .= "$key = :where_$key";
+            } else {
+                $whereDetails .= " AND $key = :where_$key";
+            }
+            $idx++;
+        }
+
+        $whereDetails = ltrim($whereDetails, ' AND ');
+
+        // Prepare statement.
+        $stmt = $this->prepare("UPDATE $table SET $fieldDetails WHERE $whereDetails");
+
+        // Bind fields
+        foreach ($data as $key => $value) {
+            $stmt->bindValue(":field_$key", $value);
+        }
+
+        // Bind values
+        foreach ($where as $key => $value) {
+            $stmt->bindValue(":where_$key", $value);
+        }
+
+        // Execute
+        $this->queryCount++;
+
+        if (!$stmt->execute()) {
+            return false;
+        }
+
+        // Row count, affected rows
+        return $stmt->rowCount();
+    }
+
+    /**
+     * Execute Delete statement, this will automatically build the query for you.
+     *
+     * @param string $table Table to execute the statement.
+     * @param array $where Use key->value like column->value for where mapping.
+     * @return bool|int Row Count, number of deleted rows, or false on failure.
+     *
+     * @throws \Exception
+     */
+    public function delete($table, $where)
+    {
+        // Sort in where keys.
+        ksort($where);
+
+        // Bind the where details.
+        $whereDetails = null;
+        $idx = 0;
+
+        foreach ($where as $key => $value) {
+            if ($idx == 0) {
+                $whereDetails .= "$key = :$key";
+            } else {
+                $whereDetails .= " AND $key = :$key";
+            }
+            $idx++;
+        }
+
+        $whereDetails = ltrim($whereDetails, ' AND ');
+
+        // Prepare statement
+        $stmt = $this->prepare("DELETE FROM $table WHERE $whereDetails");
+
+        // Bind
+        foreach ($where as $key => $value) {
+            $stmt->bindValue(":$key", $value);
+        }
+
+        // Execute and return if failure.
+        $this->queryCount++;
+
+        if (!$stmt->execute()) {
+            return false;
+        }
+
+        // Return rowcount when succeeded.
+        return $stmt->rowCount();
+    }
+
+    /**
+     * Prepare the query and return a prepared statement.
+     * Optional bind is available.
+     *
+     * @param string $sql Query
+     * @param array $bind optional binding values
+     * @param int|null $method custom method
+     * @param string|null $class class fetch, the class, full class with namespace.
+     * @return \PDOStatement|mixed
+     *
+     * @throws \Exception
+     */
+    public function rawPrepare($sql, $bind = array(), $method = null, $class = null)
+    {
+
+        // Prepare and get statement from PDO.
+        $stmt = $this->prepare($sql);
+
+        // Bind the key and values (only if given).
+        foreach ($bind as $key => $value) {
+            if (is_int($value)) {
+                $stmt->bindValue("$key", $value, \PDO::PARAM_INT);
+            } else {
+                $stmt->bindValue("$key", $value);
+            }
+        }
+
+        $this->queryCount++;
+
+        return $stmt;
+    }
+
+    /**
+     * Truncate table
+     * @param  string $table table name
+     * @return int number of rows affected
+     */
+    abstract public function truncate($table);
+
+    /**
+     * Get total executed queries.
+     *
+     * @return int
+     */
+    public function getTotalQueries()
+    {
+        return $this->queryCount;
+    }
+}

--- a/system/Database/Engine/Base.php
+++ b/system/Database/Engine/Base.php
@@ -22,7 +22,7 @@ abstract class Base extends \PDO implements Engine
     private $config;
 
     /** @var int Counting how much queries have been executed in total. */
-    private $queryCount;
+    protected $queryCount;
 
     /**
      * MySQLEngine constructor.

--- a/system/Database/Engine/Base.php
+++ b/system/Database/Engine/Base.php
@@ -74,7 +74,7 @@ abstract class Base extends \PDO implements Engine
     /**
      * Get the current fetching Method
      */
-    public function getMethod()
+    public function getFetchMethod()
     {
         return $this->method;
     }

--- a/system/Database/Engine/Base.php
+++ b/system/Database/Engine/Base.php
@@ -35,7 +35,7 @@ abstract class Base extends \PDO implements Engine
     public function __construct($dsn, $config = array(), $options = array()) {
         // Check for valid Config.
         if (! is_array($config) || ! is_array($options)) {
-            throw new \UnexpectedValueException('Parameter should be an Array');
+            throw new \UnexpectedValueException('Config and Options parameters should be Arrays');
         }
 
         // Will set the default method when provided in the config.

--- a/system/Database/Engine/Base.php
+++ b/system/Database/Engine/Base.php
@@ -19,7 +19,7 @@ abstract class Base extends \PDO implements Engine
     protected $method = \PDO::FETCH_OBJ;
 
     /** @var array Config from the user's app config. */
-    private $config;
+    protected $config;
 
     /** @var int Counting how much queries have been executed in total. */
     protected $queryCount;

--- a/system/Database/Engine/Base.php
+++ b/system/Database/Engine/Base.php
@@ -16,7 +16,7 @@ use Nova\Database\Manager;
 abstract class Base extends \PDO implements Engine
 {
     /** @var int PDO Fetch method. */
-    private $method = \PDO::FETCH_OBJ;
+    protected $method = \PDO::FETCH_OBJ;
 
     /** @var array Config from the user's app config. */
     private $config;
@@ -70,6 +70,14 @@ abstract class Base extends \PDO implements Engine
      * @return string
      */
     abstract public function getDriverCode();
+
+    /**
+     * Get the current fetching Method
+     */
+    public function getMethod()
+    {
+        return $this->method;
+    }
 
     /**
      * Get configuration for instance

--- a/system/Database/Engine/MySQL.php
+++ b/system/Database/Engine/MySQL.php
@@ -11,15 +11,11 @@ namespace Nova\Database\Engine;
 
 use Nova\Database\Engine;
 use Nova\Database\Manager;
+use Nova\Database\Engine\Base as BaseEngine;
 
-class MySQL extends \PDO implements Engine
+
+class MySQL extends BaseEngine
 {
-    /** @var int PDO Fetch method. */
-    private $method = \PDO::FETCH_OBJ;
-    /** @var array Config from the user's app config. */
-    private $config;
-    /** @var int Counting how much queries have been executed in total. */
-    private $queryCount;
 
     /**
      * MySQLEngine constructor.
@@ -31,39 +27,34 @@ class MySQL extends \PDO implements Engine
      */
     public function __construct($config) {
         // Check for valid Config.
-        if (!is_array($config)) {
+        if (! is_array($config)) {
             throw new \UnexpectedValueException('Parameter should be an Array');
         }
 
-        // Will set the default method when provided in the config.
-        if (isset($config['fetch_method'])) {
-            $this->method = $config['fetch_method'];
-        }
-
         // Default port if no port is provided.
-        if (!isset($config['port'])) {
+        if (! isset($config['port'])) {
             $config['port'] = 3306;
         }
 
-        // Some Database Servers go crazy when a charset parameter is added, then we should make that parameter optional.
-        if (!isset($config['charset'])) {
+        // Some Database Servers go crazy when a charset parameter is added, then we should make it optional.
+        if (! isset($config['charset'])) {
             $charsetStr = "";
         }
         else {
             $charsetStr = ($config['charset'] == 'auto') ? "" : ";charset=" . $config['charset'];
         }
 
-        // Reset query counter
-        $this->queryCount = 0;
+        // Prepare the PDO's options.
+        $options = array();
 
-        // Set config in class variable.
-        $this->config = $config;
+        if (isset($config['compress']) && ($config['compress'] === true)) {
+            array_push($options, \PDO::MYSQL_ATTR_COMPRESS, true);
+        }
 
-        $dsn = "mysql:host=" . $config['host'] . ";port=" . $config['port'] . ";dbname=" . $config['database'] . $charsetStr;
+        // Prepare the PDO's DSN
+        $dsn = "mysql:host=" .$config['host'] .";port=" .$config['port'] .";dbname=" .$config['database'] .$charsetStr;
 
-        parent::__construct($dsn, $config['username'], $config['password'], array(\PDO::MYSQL_ATTR_COMPRESS => true));
-
-        $this->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+        parent::__construct($dsn, $config, $options);
     }
 
     /**
@@ -76,24 +67,6 @@ class MySQL extends \PDO implements Engine
     }
 
     /**
-     * Get configuration for instance
-     * @return array
-     */
-    public function getConfiguration()
-    {
-        return $this->config;
-    }
-
-    /**
-     * Get native connection. Could be \PDO
-     * @return \PDO
-     */
-    public function getConnection()
-    {
-        return $this;
-    }
-
-    /**
      * Get driver code, used in config as driver string.
      * @return string
      */
@@ -102,194 +75,23 @@ class MySQL extends \PDO implements Engine
         return Manager::DRIVER_MYSQL;
     }
 
-
-    /**
-     * Basic execute statement. Only for queries with no binding parameters
-     * This method is not SQL Injection safe! Please remember to don't use this with dynamic content!
-     * This will only return an array or boolean. Depends on your operation and if fetch is on.
-     *
-     * @param $sql
-     * @param $fetch
-     * @return mixed
-     */
-    public function raw($sql, $fetch = false)
-    {
-        $method = $this->method;
-
-        if ($this->method === \PDO::FETCH_CLASS) {
-            // We can't fetch class here to stay conform the interface, make it OBJ for this simple query.
-            $method = \PDO::FETCH_OBJ;
-        }
-
-        $this->queryCount++;
-
-        if (!$fetch) {
-            return $this->exec($sql);
-        }
-
-        $statement = $this->query($sql, $method);
-
-        return $statement->fetchAll();
-    }
-
-    public function rawQuery($sql)
-    {
-        // We can't fetch class here to stay conform the interface, make it OBJ for this simple query.
-        $method = ($this->method !== \PDO::FETCH_CLASS) ? $this->method : \PDO::FETCH_OBJ;
-
-        $this->queryCount++;
-
-        // We don't want to map in memory an entire Billion Records Table, so we return right on a Statement.
-        return $this->query($sql, $method);
-    }
-
-    /**
-     * Execute Select Query, bind values into the $sql query. And give optional method and class for fetch result
-     * The result MUST be an array!
-     *
-     * @param string $sql
-     * @param array $bindParams
-     * @param bool $fetchAll Ask the method to fetch all the records or not.
-     * @param null $method Customized method for fetching, null for engine default or config default.
-     * @param null $class Class for fetching into classes.
-     * @return array|null
-     *
-     * @throws \Exception
-     */
-    public function select($sql, $bindParams = array(), $fetchAll = false, $method = null, $class = null)
-    {
-        // Append select if it isn't appended.
-        if (strtolower(substr($sql, 0, 7)) !== 'select ') {
-            $sql = "SELECT " . $sql;
-        }
-
-        // What method? Use default if no method is given my the call.
-        if ($method === null) {
-            $method = $this->method;
-        }
-
-        // Prepare and get statement from PDO.
-        $stmt = $this->prepare($sql);
-
-        // Bind the key and values (only if given).
-        foreach ($bindParams as $key => $value) {
-            if (is_int($value)) {
-                $stmt->bindValue("$key", $value, \PDO::PARAM_INT);
-            } else {
-                $stmt->bindValue("$key", $value);
-            }
-        }
-
-        // Execute, we should capture the status of the result.
-        $status = $stmt->execute();
-
-        $this->queryCount++;
-
-        // If failed, return now, and don't continue with fetching.
-        if (!$status) {
-            return false;
-        }
-
-        if($fetchAll) {
-            // Continue with fetching all records.
-            if ($method === \PDO::FETCH_CLASS) {
-                if (!$class) {
-                    throw new \Exception("No class is given but you are using the PDO::FETCH_CLASS method!");
-                }
-
-                // Fetch in class
-                $result = $stmt->fetchAll($method, $class);
-            }
-            else {
-                $result = $stmt->fetchAll($method);
-            }
-
-            if (is_array($result) && count($result) > 0) {
-                return $result;
-            }
-
-            return false;
-        }
-
-        // Continue with fetching one record.
-        if ($method === \PDO::FETCH_CLASS) {
-            if (!$class) {
-                throw new \Exception("No class is given but you are using the PDO::FETCH_CLASS method!");
-            }
-
-            // Fetch in class
-            return $stmt->fetch($method, $class);
-        }
-        else {
-            return $stmt->fetch($method);
-        }
-    }
-
-    /**
-     * Convenience method for fetching one record.
-     *
-     * @param string $sql
-     * @param array $bindParams
-     * @param null $method Customized method for fetching, null for engine default or config default.
-     * @param null $class Class for fetching into classes.
-     * @return object|array|null|false
-     * @throws \Exception
-     */
-    public function selectOne($sql, $bindParams = array(), $method = null, $class = null)
-    {
-        return $this->select($sql, $bindParams, false, $method, $class);
-    }
-
-    /**
-     * Convenience method for fetching all records.
-     *
-     * @param string $sql
-     * @param array $bindParams
-     * @param null $method Customized method for fetching, null for engine default or config default.
-     * @param null $class Class for fetching into classes.
-     * @return array|null|false
-     * @throws \Exception
-     */
-    public function selectAll($sql, $bindParams = array(), $method = null, $class = null)
-    {
-        return $this->select($sql, $bindParams, true, $method, $class);
-    }
-
-    /**
-     * Execute insert query, will automatically build query for you.
-     * You can also give an array as $data, this will try to insert each entry in the array.
-     * Not all engine's support this! Check the manual!
-     *
-     * @param string $table Table to execute the insert.
-     * @param array $data Represents one record, could also have multidimensional arrays inside to insert
-     *                    multiple rows in one call. The engine must support this! Check manual!
-     * @param bool $transaction Use PDO Transaction. If one insert will fail we will rollback immediately. Default false.
-     * @param bool $multipleInserts Specify to execute multiple inserts.
-     * @return int|bool|array Could be false on error, or one single id inserted, or an array of inserted id's.
-     *
-     * @throws \Exception
-     */
-    public function insert($table, $data, $transaction = false, $multipleInserts = false)
+    public function insertBatch($table, $data, $transaction = false)
     {
         // Check for valid data.
         if (!is_array($data)) {
-            throw new \Exception("Data to insert must be an array of column -> value. MySQL Driver supports multidimensional multiple inserts.");
-        }
-
-        if (! $multipleInserts) {
-            // Currently not using the multi insert, make data to use same code.
-            $data = array($data);
+            throw new \Exception("Data to insert must be an array of column -> value.");
         }
 
         // Transaction?
-        $transactionStatus = false;
+        $status = false;
 
         if ($transaction) {
-            $transactionStatus = $this->beginTransaction();
+            $status = $this->beginTransaction();
         }
 
         // Holding status
         $failure = false;
+
         $ids = array();
 
         // Loop every record to insert
@@ -320,8 +122,8 @@ class MySQL extends \PDO implements Engine
         }
 
         // Commit when in transaction
-        if ($transaction && $transactionStatus) {
-            $failure = !$this->commit();
+        if (! $failure && $transaction && $status) {
+            $failure = ! $this->commit();
         }
 
         // Check for failures
@@ -335,161 +137,7 @@ class MySQL extends \PDO implements Engine
             return false;
         }
 
-        if (! $multipleInserts) {
-            return (count($ids) == 1) ? array_shift($ids) : 0;
-        }
-
         return $ids;
-    }
-
-    /**
-     * Execute insert query, will automatically build query for you.
-     * You can also give an array as $data, this will try to insert each entry in the array.
-     * Not all engine's support this! Check the manual!
-     *
-     * @param string $table Table to execute the insert.
-     * @param array $data Represents one record, could also have multidimensional arrays inside to insert
-     *                    multiple rows in one call. The engine must support this! Check manual!
-     * @param bool $transaction Use PDO Transaction. If one insert will fail we will rollback immediately. Default false.
-     * @return int|bool|array Could be false on error, or one single id inserted, or an array of inserted id's.
-     *
-     * @throws \Exception
-     */
-    public function insertAll($table, $data, $transaction = false)
-    {
-        // Check for valid data.
-        if (!is_array($data)) {
-            throw new \Exception("Data to insert must be an array of column -> value. MySQL Driver supports multidimensional multiple inserts.");
-        }
-
-        return $this->insert($table, $data, $transaction, is_array($data[0]));
-    }
-
-    /**
-     * Execute update query, will automatically build query for you.
-     *
-     * @param string $table Table to execute the statement.
-     * @param array $data The updated array, will map into an update statement.
-     * @param array $where Use key->value like column->value for where mapping.
-     * @param int $limit Limit the update statement, not supported by every engine!
-     * @return int|bool
-     *
-     * @throws \Exception
-     */
-    public function update($table, $data, $where, $limit = 1)
-    {
-        // Sort on key
-        ksort($data);
-
-        // Column :bind for auto binding.
-        $fieldDetails = null;
-
-        foreach ($data as $key => $value) {
-            $fieldDetails .= "$key = :field_$key,";
-        }
-
-        $fieldDetails = rtrim($fieldDetails, ',');
-
-        // Where :bind for auto binding
-        $whereDetails = null;
-        $idx = 0;
-
-        foreach ($where as $key => $value) {
-            if ($idx == 0) {
-                $whereDetails .= "$key = :where_$key";
-            } else {
-                $whereDetails .= " AND $key = :where_$key";
-            }
-            $idx++;
-        }
-
-        $whereDetails = ltrim($whereDetails, ' AND ');
-
-        // Limit
-        $optionalLimit = "";
-
-        if (is_numeric($limit)) {
-            $optionalLimit = " LIMIT " . $limit;
-        }
-
-        // Prepare statement.
-        $stmt = $this->prepare("UPDATE $table SET $fieldDetails WHERE $whereDetails $optionalLimit");
-
-        // Bind fields
-        foreach ($data as $key => $value) {
-            $stmt->bindValue(":field_$key", $value);
-        }
-
-        // Bind values
-        foreach ($where as $key => $value) {
-            $stmt->bindValue(":where_$key", $value);
-        }
-
-        // Execute
-        $this->queryCount++;
-
-        if (!$stmt->execute()) {
-            return false;
-        }
-
-        // Row count, affected rows
-        return $stmt->rowCount();
-    }
-
-    /**
-     * Execute Delete statement, this will automatically build the query for you.
-     *
-     * @param string $table Table to execute the statement.
-     * @param array $where Use key->value like column->value for where mapping.
-     * @param int $limit Limit the update statement, not supported by every engine!
-     * @return bool|int Row Count, number of deleted rows, or false on failure.
-     *
-     * @throws \Exception
-     */
-    public function delete($table, $where, $limit = 1)
-    {
-        // Sort in where keys.
-        ksort($where);
-
-        // Bind the where details.
-        $whereDetails = null;
-        $idx = 0;
-
-        foreach ($where as $key => $value) {
-            if ($idx == 0) {
-                $whereDetails .= "$key = :$key";
-            } else {
-                $whereDetails .= " AND $key = :$key";
-            }
-            $idx++;
-        }
-
-        $whereDetails = ltrim($whereDetails, ' AND ');
-
-        // If limit is a number use a limit on the query
-        $optionalLimit = "";
-
-        if (is_numeric($limit)) {
-            $optionalLimit = "LIMIT $limit";
-        }
-
-        // Prepare statement
-        $stmt = $this->prepare("DELETE FROM $table WHERE $whereDetails $optionalLimit");
-
-        // Bind
-        foreach ($where as $key => $value) {
-            $stmt->bindValue(":$key", $value);
-        }
-
-        // Execute and return if failure.
-        $this->queryCount++;
-
-        if (!$stmt->execute()) {
-            return false;
-        }
-
-        // Return rowcount when succeeded.
-        return $stmt->rowCount();
     }
 
     /**
@@ -504,46 +152,4 @@ class MySQL extends \PDO implements Engine
         return $this->exec("TRUNCATE TABLE $table");
     }
 
-    /**
-     * Prepare the query and return a prepared statement.
-     * Optional bind is available.
-     *
-     * @param string $sql Query
-     * @param array $bind optional binding values
-     * @param int|null $method custom method
-     * @param string|null $class class fetch, the class, full class with namespace.
-     * @return \PDOStatement|mixed
-     *
-     * @throws \Exception
-     */
-    public function rawPrepare($sql, $bind = array(), $method = null, $class = null)
-    {
-
-        // Prepare and get statement from PDO.
-        $stmt = $this->prepare($sql);
-
-        // Bind the key and values (only if given).
-        foreach ($bind as $key => $value) {
-            if (is_int($value)) {
-                $stmt->bindValue("$key", $value, \PDO::PARAM_INT);
-            } else {
-                $stmt->bindValue("$key", $value);
-            }
-        }
-
-        $this->queryCount++;
-
-        return $stmt;
-    }
-
-
-    /**
-     * Get total executed queries.
-     *
-     * @return int
-     */
-    public function getTotalQueries()
-    {
-        return $this->queryCount;
-    }
 }

--- a/system/Database/Engine/SQLite.php
+++ b/system/Database/Engine/SQLite.php
@@ -11,16 +11,11 @@ namespace Nova\Database\Engine;
 
 use Nova\Database\Engine;
 use Nova\Database\Manager;
+use Nova\Database\Engine\Base as BaseEngine;
 
-class SQLite extends \PDO implements Engine
+
+class SQLite extends BaseEngine
 {
-    /** @var int PDO Fetch method. */
-    private $method = \PDO::FETCH_OBJ;
-    /** @var array Config from the user's app config. */
-    private $config;
-    /** @var int Count */
-    private $queryCount;
-
 
     /**
      * SQLiteEngine constructor.
@@ -31,25 +26,14 @@ class SQLite extends \PDO implements Engine
      */
     public function __construct($config) {
         // Check for valid Config.
-        if (!is_array($config)) {
+        if (! is_array($config)) {
             throw new \UnexpectedValueException('Parameter should be an Array');
         }
 
-        // Will set the default method when provided in the config.
-        if (isset($config['fetch_method'])) {
-            $this->method = $config['fetch_method'];
-        }
+        // Prepare the PDO's DSN
+        $dsn = "sqlite:" .BASEPATH .'storage' .DS .'persistent' .DS .$config['file'];
 
-        $this->queryCount = 0;
-
-        // Set config in class variable.
-        $this->config = $config;
-
-        $dsn = "sqlite:" . BASEPATH . 'storage' . DS . 'persistent' . DS . $config['file'];
-
-        parent::__construct($dsn);
-
-        $this->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+        parent::__construct($dsn, $config);
     }
 
     /**
@@ -62,24 +46,6 @@ class SQLite extends \PDO implements Engine
     }
 
     /**
-     * Get configuration for instance
-     * @return array
-     */
-    public function getConfiguration()
-    {
-        return $this->config;
-    }
-
-    /**
-     * Get native connection. Could be \PDO
-     * @return mixed|\PDO
-     */
-    public function getConnection()
-    {
-        return $this;
-    }
-
-    /**
      * Get driver code, used in config as driver string.
      * @return string
      */
@@ -88,377 +54,9 @@ class SQLite extends \PDO implements Engine
         return Manager::DRIVER_SQLITE;
     }
 
-    /**
-     * Basic execute statement. Only for queries with no binding parameters
-     *
-     * @param $sql
-     * @param $fetch
-     * @return mixed
-     */
-    public function raw($sql, $fetch = false)
+    public function insertBatch($table, $data, $transaction)
     {
-        $method = $this->method;
-        if ($this->method === \PDO::FETCH_CLASS) {
-            // We can't fetch class here to stay conform the interface, make it OBJ for this simple query.
-            $method = \PDO::FETCH_OBJ;
-        }
-
-        $this->queryCount++;
-
-        if (!$fetch) {
-            return $this->exec($sql);
-        }
-
-        $statement = $this->query($sql, $method);
-
-        return $statement->fetchAll();
-    }
-
-    public function rawQuery($sql)
-    {
-        // We can't fetch class here to stay conform the interface, make it OBJ for this simple query.
-        $method = ($this->method !== \PDO::FETCH_CLASS) ? $this->method : \PDO::FETCH_OBJ;
-
-        $this->queryCount++;
-
-        // We don't want to map in memory an entire Billion Records Table, so we return right on a Statement.
-        return $this->query($sql, $method);
-    }
-
-    /**
-     * Execute Query, bind values into the $sql query. And give optional method and class for fetch result
-     * The result MUST be an array!
-     *
-     * @param string $sql
-     * @param array $bindParams
-     * @param bool $fetchAll Ask the method to fetch all the records or not.
-     * @param null $method Customized method for fetching, null for engine default or config default.
-     * @param null $class Class for fetching into classes.
-     * @return array|null|false
-     * @throws \Exception
-     * @internal param array $bindParams
-     */
-    public function select($sql, $bindParams = array(), $fetchAll = false, $method = null, $class = null)
-    {
-        // Append select if it isn't
-        if (strtolower(substr($sql, 0, 7)) !== 'select ') {
-            $sql = "SELECT " . $sql;
-        }
-
-        // What method? Use default if no method is given my the call.
-        if ($method === null) {
-            $method = $this->method;
-        }
-
-        // Prepare statement
-        $stmt = $this->prepare($sql);
-
-        // Bind values
-        foreach ($bindParams as $key => $value) {
-            if (is_int($value)) {
-                $stmt->bindValue("$key", $value, \PDO::PARAM_INT);
-            } else {
-                $stmt->bindValue("$key", $value);
-            }
-        }
-
-        // Execute, hold status
-        $status = $stmt->execute();
-
-        $this->queryCount++;
-
-        // If failed, return now, and don't continue with fetching.
-        if (!$status) {
-            return false;
-        }
-
-        if($fetchAll) {
-            // Continue with fetching all records.
-            if ($method === \PDO::FETCH_CLASS) {
-                if (!$class) {
-                    throw new \Exception("No class is given but you are using the PDO::FETCH_CLASS method!");
-                }
-
-                // Fetch in class
-                $result = $stmt->fetchAll($method, $class);
-            } else {
-                $result = $stmt->fetchAll($method);
-            }
-
-            if (is_array($result) && count($result) > 0) {
-                return $result;
-            }
-
-            return false;
-        }
-
-        // Continue with fetching one record.
-        if ($method === \PDO::FETCH_CLASS) {
-            if (!$class) {
-                throw new \Exception("No class is given but you are using the PDO::FETCH_CLASS method!");
-            }
-
-            // Fetch in class
-            return $stmt->fetch($method, $class);
-        }
-        else {
-            return $stmt->fetch($method);
-        }
-    }
-
-    /**
-     * Convenience method for fetching one record.
-     *
-     * @param string $sql
-     * @param array $bindParams
-     * @param null $method Customized method for fetching, null for engine default or config default.
-     * @param null $class Class for fetching into classes.
-     * @return array|null|object|false
-     * @throws \Exception
-     */
-    public function selectOne($sql, $bindParams = array(), $method = null, $class = null)
-    {
-        return $this->select($sql, $bindParams, false, $method, $class);
-    }
-
-    /**
-     * Convenience method for fetching all records.
-     *
-     * @param string $sql
-     * @param array $bindParams
-     * @param null $method Customized method for fetching, null for engine default or config default.
-     * @param null $class Class for fetching into classes.
-     * @return array|null|false
-     * @throws \Exception
-     */
-    public function selectAll($sql, $bindParams = array(), $method = null, $class = null)
-    {
-        return $this->select($sql, $bindParams, true, $method, $class);
-    }
-
-    /**
-     * Execute insert query, will automatically build query for you.
-     * You can also give an array as $data, this will try to insert each entry in the array.
-     * Not all engine's support this! Check the manual!
-     *
-     * @param string $table Table to execute the insert.
-     * @param array $data Represents one record, could also have multidimensional arrays inside to insert
-     *                    multiple rows in one call. The engine must support this! Check manual!
-     * @param bool $transaction Use PDO Transaction. If one insert will fail we will rollback immediately. Default false.
-     * @param bool $multipleInserts Specify to execute multiple inserts.
-     * @return int|bool
-     *
-     * @throws \Exception
-     */
-    public function insert($table, $data, $transaction = false, $multipleInserts = false)
-    {
-        // Check for valid data.
-        if (!is_array($data)) {
-            throw new \Exception("Data to insert must be an array of column -> value. MySQL Driver supports multidimensional multiple inserts.");
-        }
-
-        if (! $multipleInserts) {
-            // Currently not using multi insert, make data to use same code.
-            $data = array($data);
-        }
-
-        // Transaction?
-        $transactionStatus = false;
-
-        if ($transaction) {
-            $transactionStatus = $this->beginTransaction();
-        }
-
-        // Holding status
-        $failure = false;
-        $ids = array();
-
-        // Loop every record to insert
-        foreach($data as $record) {
-            ksort($record);
-
-            $fieldNames = implode(',', array_keys($record));
-            $fieldValues = ':'.implode(', :', array_keys($record));
-
-            $stmt = $this->prepare("INSERT INTO $table ($fieldNames) VALUES ($fieldValues)");
-
-            foreach ($record as $key => $value) {
-                $stmt->bindValue(":$key", $value);
-            }
-
-            // Execute
-            $this->queryCount++;
-
-            if (!$stmt->execute()) {
-                $failure = true;
-
-                // We need to exit foreach, to inform about the error, or rollback.
-                break 1;
-            }
-
-            // If no error, capture the last inserted id
-            $ids[] = $this->lastInsertId();
-        }
-
-        // Commit when in transaction
-        if ($transaction && $transactionStatus) {
-            $failure = !$this->commit();
-        }
-
-        // Check for failures
-        if ($failure) {
-            // Ok, rollback when using transactions.
-            if ($transaction) {
-                $this->rollBack();
-            }
-
-            // False on error.
-            return false;
-        }
-
-        if (! $multipleInserts) {
-            return (count($ids) == 1) ? array_shift($ids) : 0;
-        }
-
-        return $ids;
-    }
-
-    /**
-     * Execute insert query, will automatically build query for you.
-     * You can also give an array as $data, this will try to insert each entry in the array.
-     * Not all engine's support this! Check the manual!
-     *
-     * @param string $table Table to execute the insert.
-     * @param array $data Represents one record, could also have multidimensional arrays inside to insert
-     *                    multiple rows in one call. The engine must support this! Check manual!
-     * @param bool $transaction Use PDO Transaction. If one insert will fail we will rollback immediately. Default false.
-     * @return int|bool|array Could be false on error, or one single id inserted, or an array of inserted id's.
-     *
-     * @throws \Exception
-     */
-    public function insertAll($table, $data, $transaction = false)
-    {
-        // Check for valid data.
-        if (!is_array($data)) {
-            throw new \Exception("Data to insert must be an array of column -> value. MySQL Driver supports multidimensional multiple inserts.");
-        }
-
-        return $this->insert($table, $data, $transaction, is_array($data[0]));
-    }
-
-    /**
-     * Execute update query, will automatically build query for you.
-     *
-     * @param string $table Table to execute the statement.
-     * @param array $data The updated array, will map into an update statement.
-     * @param array $where Use key->value like column->value for where mapping.
-     * @param int $limit Limit the update statement, not supported by every engine! NOT SUPPORTED BY SQLITE!
-     * @return int|bool
-     *
-     * @throws \Exception
-     */
-    public function update($table, $data, $where, $limit = 1)
-    {
-        // Sort on key
-        ksort($data);
-
-        // Column :bind for auto binding.
-        $fieldDetails = null;
-
-        foreach ($data as $key => $value) {
-            $fieldDetails .= "$key = :field_$key,";
-        }
-
-        $fieldDetails = rtrim($fieldDetails, ',');
-
-        // Where :bind for auto binding
-        $whereDetails = null;
-        $idx = 0;
-
-        foreach ($where as $key => $value) {
-            if ($idx == 0) {
-                $whereDetails .= "$key = :where_$key";
-            } else {
-                $whereDetails .= " AND $key = :where_$key";
-            }
-
-            $idx++;
-        }
-
-        $whereDetails = ltrim($whereDetails, ' AND ');
-
-        // Prepare statement.
-        $stmt = $this->prepare("UPDATE $table SET $fieldDetails WHERE $whereDetails");
-
-        // Bind fields
-        foreach ($data as $key => $value) {
-            $stmt->bindValue(":field_$key", $value);
-        }
-
-        // Bind values
-        foreach ($where as $key => $value) {
-            $stmt->bindValue(":where_$key", $value);
-        }
-
-        // Execute
-        $this->queryCount++;
-
-        if (!$stmt->execute()) {
-            return false;
-        }
-
-        // Row count, affected rows
-        return $stmt->rowCount();
-    }
-
-    /**
-     * Execute Delete statement, this will automatically build the query for you.
-     *
-     * @param string $table Table to execute the statement.
-     * @param array $where Use key->value like column->value for where mapping.
-     * @param int $limit Limit the update statement, not supported by every engine! NOT SUPPORTED BY SQLITE (most versions)
-     * @return bool
-     *
-     * @throws \Exception
-     */
-    public function delete($table, $where, $limit = 1)
-    {
-        // Sort in where keys.
-        ksort($where);
-
-        // Bind the where details.
-        $whereDetails = null;
-        $idx = 0;
-
-        foreach ($where as $key => $value) {
-            if ($idx == 0) {
-                $whereDetails .= "$key = :$key";
-            } else {
-                $whereDetails .= " AND $key = :$key";
-            }
-
-            $idx++;
-        }
-
-        $whereDetails = ltrim($whereDetails, ' AND ');
-
-        // Prepare statement
-        $stmt = $this->prepare("DELETE FROM $table WHERE $whereDetails");
-
-        // Bind
-        foreach ($where as $key => $value) {
-            $stmt->bindValue(":$key", $value);
-        }
-
-        // Execute and return if failure.
-        $this->queryCount++;
-
-        if (!$stmt->execute()) {
-            return false;
-        }
-
-        // Return rowcount when succeeded.
-        return $stmt->rowCount();
+        throw new \BadMethodCallException('Multiple Inserts are unsupported on SQLite Engine');
     }
 
     /**
@@ -468,48 +66,7 @@ class SQLite extends \PDO implements Engine
      */
     public function truncate($table)
     {
-        throw new \BadMethodCallException('TRUNCATE can not be called in SQLite Engine!');
+        throw new \BadMethodCallException('TRUNCATE called on SQLite Engine');
     }
 
-    /**
-     * Prepare the query and return a prepared statement.
-     * Optional bind is available.
-     *
-     * @param string $sql Query
-     * @param array $bind optional binding values
-     * @param int|null $method custom method
-     * @param string|null $class class fetch, the class, full class with namespace.
-     * @return \PDOStatement|mixed
-     *
-     * @throws \Exception
-     */
-    public function rawPrepare($sql, $bind = array(), $method = null, $class = null)
-    {
-        // Prepare and get statement from PDO.
-        $stmt = $this->prepare($sql);
-
-        // Bind the key and values (only if given).
-        foreach ($bind as $key => $value) {
-            if (is_int($value)) {
-                $stmt->bindValue("$key", $value, \PDO::PARAM_INT);
-            } else {
-                $stmt->bindValue("$key", $value);
-            }
-        }
-
-        $this->queryCount++;
-
-        return $stmt;
-    }
-
-
-    /**
-     * Get total executed queries.
-     *
-     * @return int
-     */
-    public function getTotalQueries()
-    {
-        return $this->queryCount;
-    }
 }

--- a/system/Database/Engine/SQLite.php
+++ b/system/Database/Engine/SQLite.php
@@ -54,7 +54,7 @@ class SQLite extends BaseEngine
         return Manager::DRIVER_SQLITE;
     }
 
-    public function insertBatch($table, $data, $transaction)
+    public function insertBatch($table, $data, $transaction = false)
     {
         throw new \BadMethodCallException('Multiple Inserts are unsupported on SQLite Engine');
     }

--- a/system/Database/Manager.php
+++ b/system/Database/Manager.php
@@ -114,17 +114,17 @@ abstract class Manager
                 throw new \UnexpectedValueException('Fully qualified Class Name while a Module is specified');
             }
 
-            // A fully qualified className, with complete namespace.
-            $classPath = '\\';
+            // A fully qualified className.
+            $basePath = '\\';
         }
         else if($module !== null) {
-            $classPath = '\App\Modules\\'.$module.'\Services\Database\\';
+            $basePath = '\App\Modules\\'.$module.'\Services\Database\\';
         }
         else {
-            $classPath = '\App\Services\Database\\';
+            $basePath = '\App\Services\Database\\';
         }
 
-        $className = $classPath.$serviceName;
+        $className = $basePath.$serviceName;
 
         if (($engine !== null) && is_string($engine)) {
             $engine = self::getEngine($engine);


### PR DESCRIPTION
This pull request introduce the refactoring of Database Engines, to avoid the redundant code and to consolidate the structure.

In principle, the common used methods from **MySQL** and **SQLite** engines are moved in a base one, called **\Nova\Database\Engine\Base** and used as parent.

In other hand, some changes are introduced:

The **insertAll** method become **insertBatch** and now is totally independent from **insert** one, which lose its ability to manage the multi-inserts, to simplify the code and those multi-inserts being a MySQL thingy. Then, under **SQLite Engine**,  the method **insertBatch** will nuke the fridge (go Exception).

The methods **update** and **delete** lose the ability to establish **LIMIT**s as being a MySQL thingy and, considered by us, permitting developing bad habits on coding; as **UPDATE** and **DELETE** should be always atomic, with a very precise specified **WHERE**.

### PS. Our personal opinion about introducing Tests just for fun:

![rudeboy](https://cloud.githubusercontent.com/assets/13488485/12008011/46f27768-ac21-11e5-87bf-9be6b93d3e14.jpg)