### PR TITLE
3.0 - Final Phase, stage continued #19

### DIFF
--- a/app/Config/config.php
+++ b/app/Config/config.php
@@ -91,22 +91,22 @@ Config::set('database', array(
     'default' => array(
         'engine' => 'mysql',
         'config' => array(
-            'host'          => 'localhost',
-            'port'          => 3306, // Not required, default is 3306
-            'database'      => 'dbname',
-            'username'      => 'root',
-            'password'      => 'password',
-            'fetch_method'  => \PDO::FETCH_ASSOC, // Not required, default is FETCH_ASSOC.
-            'charset'       => 'utf8', // Not required, default and recommended is utf8.
-            'compress'      => false   // Changing to true will hugely improve the persormance on remote servers.
+            'host'        => 'localhost',
+            'port'        => 3306, // Not required, default is 3306
+            'database'    => 'dbname',
+            'username'    => 'root',
+            'password'    => 'password',
+            'return_type' => 'array', // Not required, default is 'array'.
+            'charset'     => 'utf8',  // Not required, default and recommended is utf8.
+            'compress'    => false    // Changing to true will hugely improve the persormance on remote servers.
         )
     ),
     /** Extra connections can be added here, some examples: */
     'sqlite' => array(
         'engine' => 'sqlite',
         'config' => array(
-            'file'          => 'database.sqlite',
-            'fetch_method'  => \PDO::FETCH_OBJ // Not required, default is OBJ.
+            'file'         => 'database.sqlite',
+            'return_type'  => 'object' // Not required, default is 'array'.
         )
     )
 

--- a/app/Core/BaseModel.php
+++ b/app/Core/BaseModel.php
@@ -93,9 +93,11 @@ class BaseModel extends Model
     protected $temp_return_type = null;
 
     /**
-     * The select limits.
+     * The select LIMIT and WHERE arrays.
      */
     protected $temp_select_limit = null;
+
+    protected $temp_select_where = array();
 
     /**
      * Protected, non-modifiable attributes
@@ -204,12 +206,12 @@ class BaseModel extends Model
         // Prepare the WHERE details.
         $whereDetails = '';
 
-        if(is_array($where)) {
-            ksort($where);
+        if(! empty($this->temp_select_where)) {
+            ksort($this->temp_select_where);
 
             $idx = 0;
 
-            foreach ($where as $key => $value) {
+            foreach ($this->temp_select_where as $key => $value) {
                 if($idx > 0) {
                     $whereDetails .= ' AND ';
                 }
@@ -232,13 +234,10 @@ class BaseModel extends Model
 
                 $idx++;
             }
-        }
-        else if(is_string($where)) {
-            $whereDetails = $where;
-        }
 
-        if(! empty($whereDetails)) {
-            $whereDetails = 'WHERE ' .$whereDetails;
+            if(! empty($whereDetails)) {
+                $whereDetails = 'WHERE ' .$whereDetails;
+            }
         }
 
         // Prepare the LIMIT details.
@@ -251,7 +250,7 @@ class BaseModel extends Model
                 $limitDetails = '0, ' .$limit;
             }
             else if(is_array($limit)) {
-                $limitDetails = implode(',', $limit);
+                $limitDetails = implode(', ', $limit);
             }
 
             if(! empty($limitDetails)) {
@@ -280,6 +279,9 @@ class BaseModel extends Model
 
         // Make sure our temp return type is correct.
         $this->temp_return_type = $this->return_type;
+
+        // Make sure our temp where is correct.
+        $this->temp_select_where = array();
 
         // Make sure our temp limit is correct.
         $this->temp_select_limit = null;
@@ -358,6 +360,13 @@ class BaseModel extends Model
         $this->protected_attributes[] = $field;
 
         return $this;
+    }
+
+    public function where($field, $value)
+    {
+         array_push($this->temp_select_where, $field, $value);
+
+         return $this;
     }
 
     public function limit()

--- a/app/Core/BaseModel.php
+++ b/app/Core/BaseModel.php
@@ -277,10 +277,7 @@ class BaseModel extends Model
 
     public function insert($data)
     {
-        $data = $this->trigger('before_insert', array(
-            'method' =>'insert',
-            'fields' => $data
-        ));
+        $data = $this->trigger('before_insert', array('method' =>'insert', 'fields' => $data));
 
         $result = $this->db->insert($this->table_name, $data);
 
@@ -295,11 +292,7 @@ class BaseModel extends Model
 
     public function update($data, $where)
     {
-        $data = $this->trigger('before_update', array(
-            'method' =>'update',
-            'where'  => $where,
-            'fields' => $data
-        ));
+        $data = $this->trigger('before_update', array('method' =>'update', 'where'  => $where, 'fields' => $data));
 
         $result = $this->db->update($this->table_name, $data, $where);
 
@@ -353,7 +346,7 @@ class BaseModel extends Model
         $sql = "SELECT $fieldDetails FROM $table $whereDetails $limitDetails ";
 
         //
-        $this->trigger('before_select', array('method' => 'select','where' => $where, 'fields' => $fields));
+        $this->trigger('before_select', array('method' => 'select', 'where' => $where, 'fields' => $fields));
 
         $result = $this->db->select($sql, $bindParams, $fetchAll, $this->temp_return_type);
 

--- a/app/Core/BaseModel.php
+++ b/app/Core/BaseModel.php
@@ -230,7 +230,7 @@ class BaseModel extends Model
      *
      * @return object or FALSE
      */
-    public function find_many_by()
+    public function find_many_by($where)
     {
         $where = func_get_args();
 

--- a/app/Core/BaseModel.php
+++ b/app/Core/BaseModel.php
@@ -165,12 +165,22 @@ class BaseModel extends Model
      *
      * @return object
      */
-    public function find_by($where)
+    public function find_by()
     {
-        if(! is_array($where)) {
-            throw new \UnexpectedValueException('Parameter should be an Array');
+        // Prepare the parameters.
+        $params = func_get_args();
+
+        if(empty($params)) {
+            throw new \UnexpectedValueException('The method must have parameters');
         }
 
+        if (count($params) == 1) {
+            $where = array($params[0] => '');
+        } else {
+            $where = array($params[0] => $params[1]);
+        }
+
+        //
         $bindParams = array();
 
         // Get the TABLE name.
@@ -243,8 +253,22 @@ class BaseModel extends Model
      *
      * @return object or FALSE
      */
-    public function find_all($where = array())
+    public function find_all()
     {
+        // Prepare the parameters.
+        $params = func_get_args();
+
+        if(empty($params)) {
+            $where = array();
+        }
+        else if (count($params) == 1) {
+            $where = array($params[0] => '');
+        }
+        else {
+            $where = array($params[0] => $params[1]);
+        }
+
+        //
         if(! is_array($where)) {
             throw new \UnexpectedValueException('Parameter should be an Array');
         }
@@ -654,11 +678,20 @@ class BaseModel extends Model
 
         ksort($where);
 
-        $idx = 0;
+        $idx = -1;
 
         foreach ($where as $key => $value) {
+            $idx++;
+
             if($idx > 0) {
                 $whereDetails .= ' AND ';
+            }
+
+            if(empty($value)) {
+                // A string based condition; simplify its white spaces and use it directly.
+                $result .= preg_replace('/\s+/', ' ', trim($key));
+
+                continue;
             }
 
             if(strpos($key, ' ') !== false) {
@@ -676,8 +709,6 @@ class BaseModel extends Model
             $result .= "$key $operator :$key";
 
             $bindParams[$key] = $value;
-
-            $idx++;
         }
 
         if(! empty($result)) {

--- a/app/Core/BaseModel.php
+++ b/app/Core/BaseModel.php
@@ -230,7 +230,7 @@ class BaseModel extends Model
      *
      * @return object or FALSE
      */
-    public function find_many_by($where)
+    public function find_many_by()
     {
         $where = func_get_args();
 

--- a/app/Core/BaseModel.php
+++ b/app/Core/BaseModel.php
@@ -140,8 +140,8 @@ class BaseModel extends Model
             throw new \UnexpectedValueException('Parameter should be an Integer');
         }
 
-        // Prepare the TABLE details.
-        $table = DB_PREFIX .$this->table_name;
+        // Get the TABLE name.
+        $table = $this->table_name;
 
         //
         $this->trigger('before_find', array('id' => $id, 'method' => 'find'));
@@ -173,8 +173,8 @@ class BaseModel extends Model
 
         $bindParams = array();
 
-        // Prepare the TABLE details.
-        $table = DB_PREFIX .$this->table_name;
+        // Get the TABLE name.
+        $table = $this->table_name;
 
         // Prepare the WHERE details.
         $whereDetails = $this->whereDetails($where, $bindParams);
@@ -210,8 +210,8 @@ class BaseModel extends Model
             throw new \UnexpectedValueException('Parameter should be an Array');
         }
 
-        // Prepare the TABLE details.
-        $table = DB_PREFIX .$this->table_name;
+        // Get the TABLE name.
+        $table = $this->table_name;
 
         // Prepare the SQL Query.
         $sql = "SELECT * FROM $table WHERE " .$this->primary_key ." IN (".implode(',', $values) .")";
@@ -245,8 +245,8 @@ class BaseModel extends Model
      */
     public function find_all($where = array())
     {
-        // Prepare the TABLE details.
-        $table = DB_PREFIX .$this->table_name;
+        // Get the TABLE name.
+        $table = $this->table_name;
 
         // Prepare the WHERE details.
         $whereDetails = $this->whereDetails($where, $bindParams);
@@ -313,8 +313,8 @@ class BaseModel extends Model
     {
         $bindParams = array();
 
-        // Prepare the TABLE details.
-        $table = DB_PREFIX .$this->table_name;
+        // Get the TABLE name.
+        $table = $this->table_name;
 
         // Prepare the WHAT details.
         $fieldDetails = '*';
@@ -448,7 +448,7 @@ class BaseModel extends Model
      */
     public function is_unique($field, $value)
     {
-        $sql = "SELECT $field FROM " .DB_PREFIX .$this->table_name ." WHERE $field = :$field";
+        $sql = "SELECT $field FROM " .$this->table_name ." WHERE $field = :$field";
 
         $data = $this->db->selectAll($sql, array($field => $value));
 

--- a/app/Core/BaseModel.php
+++ b/app/Core/BaseModel.php
@@ -175,21 +175,6 @@ class BaseModel extends Model
     {
         $bindParams = array();
 
-        // Prepare the parameters.
-        $className = null;
-
-        if($this->temp_return_type == 'array') {
-            $fetchMethod = \PDO::FETCH_ASSOC;
-        }
-        else if($this->temp_return_type == 'object') {
-            $fetchMethod = \PDO::FETCH_OBJ;
-        }
-        else {
-            $fetchMethod = \PDO::FETCH_CLASS;
-
-            $className = $this->temp_return_type;
-        }
-
         // Prepare the TABLE details.
         $table = DB_PREFIX .$this->table_name;
 
@@ -268,7 +253,7 @@ class BaseModel extends Model
             'fields' => $fields
         ));
 
-        $result = $this->db->select($sql, $bindParams, $fetchAll, $fetchMethod, $className);
+        $result = $this->db->select($sql, $bindParams, $fetchAll, $this->temp_return_type);
 
         $result = $this->trigger('after_select', array(
             'method' => 'select'

--- a/app/Core/BaseModel.php
+++ b/app/Core/BaseModel.php
@@ -269,10 +269,6 @@ class BaseModel extends Model
      */
     public function find_all($where = array())
     {
-        if(! is_array($where)) {
-            throw new \UnexpectedValueException('Parameter should be an Array');
-        }
-
         // Get the TABLE name.
         $table = $this->table_name;
 

--- a/app/Core/BaseModel.php
+++ b/app/Core/BaseModel.php
@@ -183,7 +183,7 @@ class BaseModel extends Model
         $sql = "SELECT * FROM $table WHERE $whereDetails;";
 
         //
-        $this->trigger('before_find', ['method' => 'find_by', 'fields' => $where]);
+        $this->trigger('before_find', array('method' => 'find_by', 'fields' => $where));
 
         $result = $this->db->select($sql, $bindParams, false, $this->temp_return_type);
 

--- a/app/Core/BaseModel.php
+++ b/app/Core/BaseModel.php
@@ -245,6 +245,10 @@ class BaseModel extends Model
      */
     public function find_all($where = array())
     {
+        if(! is_array($where)) {
+            throw new \UnexpectedValueException('Parameter should be an Array');
+        }
+
         // Get the TABLE name.
         $table = $this->table_name;
 

--- a/app/Core/BaseModel.php
+++ b/app/Core/BaseModel.php
@@ -144,7 +144,7 @@ class BaseModel extends Model
         $this->trigger('before_find', array('id' => $id, 'method' => 'find'));
 
         // Prepare the SQL Query.
-        $sql = "SELECT * FROM " .$this->table_name ." WHERE " .$this->primary_key ." = :param";
+        $sql = "SELECT * FROM " .$this->table() ." WHERE " .$this->primary_key ." = :param";
 
         $result = $this->db->select($sql, array('param' => $id), true, $this->temp_return_type);
 
@@ -187,7 +187,7 @@ class BaseModel extends Model
         $whereDetails = $this->whereDetails($where, $bindParams);
 
         // Prepare the SQL Query.
-        $sql = "SELECT * FROM " .$this->table_name ." $whereDetails";
+        $sql = "SELECT * FROM " .$this->table() ." $whereDetails";
 
         //
         $this->trigger('before_find', array('method' => 'find_by', 'fields' => $where));
@@ -218,7 +218,7 @@ class BaseModel extends Model
         }
 
         // Prepare the SQL Query.
-        $sql = "SELECT * FROM " .$this->table_name ." WHERE " .$this->primary_key ." IN (".implode(',', $values) .")";
+        $sql = "SELECT * FROM " .$this->table() ." WHERE " .$this->primary_key ." IN (".implode(',', $values) .")";
 
         //
         $result = $this->db->select($sql, array(), true, $this->temp_return_type);
@@ -267,7 +267,7 @@ class BaseModel extends Model
         $whereDetails = $this->whereDetails($where, $bindParams);
 
         // Prepare the SQL Query.
-        $sql = "SELECT * FROM " .$this->table_name ." $whereDetails";
+        $sql = "SELECT * FROM " .$this->table() ." $whereDetails";
 
         //
         $this->trigger('before_find', array('method' => 'find_all', 'fields' => $where));
@@ -290,7 +290,7 @@ class BaseModel extends Model
     {
         $data = $this->trigger('before_insert', array('method' =>'insert', 'fields' => $data));
 
-        $result = $this->db->insert($this->table_name, $data);
+        $result = $this->db->insert($this->table(), $data);
 
         $result = $this->trigger('after_insert', array(
             'method' => 'insert',
@@ -305,7 +305,7 @@ class BaseModel extends Model
     {
         $data = $this->trigger('before_update', array('method' =>'update', 'where'  => $where, 'fields' => $data));
 
-        $result = $this->db->update($this->table_name, $data, $where);
+        $result = $this->db->update($this->table(), $data, $where);
 
         $result = $this->trigger('after_update', array(
             'method' => 'update'
@@ -351,7 +351,7 @@ class BaseModel extends Model
         }
 
         // Prepare the SQL Query
-        $sql = "SELECT $fieldDetails FROM " .$this->table_name ." $whereDetails $limitDetails ";
+        $sql = "SELECT $fieldDetails FROM " .$this->table() ." $whereDetails $limitDetails ";
 
         //
         $this->trigger('before_select', array('method' => 'select', 'where' => $where, 'fields' => $fields));
@@ -405,7 +405,7 @@ class BaseModel extends Model
     {
         $this->trigger('before_delete', array('method' =>'delete', 'where' => $where));
 
-        $result = $this->db->delete($this->table_name, $where);
+        $result = $this->db->delete($this->table(), $where);
 
         $result = $this->trigger('after_delete', array(
             'method' => 'delete'
@@ -446,7 +446,7 @@ class BaseModel extends Model
      */
     public function is_unique($field, $value)
     {
-        $sql = "SELECT $field FROM " .$this->table_name ." WHERE $field = :$field";
+        $sql = "SELECT $field FROM " .$this->table() ." WHERE $field = :$field";
 
         $data = $this->db->selectAll($sql, array($field => $value));
 

--- a/app/Core/BaseModel.php
+++ b/app/Core/BaseModel.php
@@ -95,9 +95,14 @@ class BaseModel extends Model
     protected $temp_return_type = null;
 
     /**
-     * Temporary where attributes.
+     * Temporary select's WHERE attributes.
      */
     protected $temp_select_where = array();
+
+    /**
+     * Temporary select's LIMIT attributes.
+     */
+    protected $temp_select_limit = null;
 
     /**
      * Protected, non-modifiable attributes
@@ -197,7 +202,7 @@ class BaseModel extends Model
 
         // Reset our select WHEREs
         $this->temp_select_where = array();
-        
+
         return $result;
     }
 
@@ -406,11 +411,6 @@ class BaseModel extends Model
         return $result;
     }
 
-    public where($field, $value = '')
-    {
-        array_push($this->temp_select_where, $field, $value);
-    }
-
     public function query($sql)
     {
         return $this->db->rawQuery($sql);
@@ -489,6 +489,13 @@ class BaseModel extends Model
     public function as_object($class = null)
     {
         $this->temp_return_type = ! empty($class) ? $class : 'object';
+
+        return $this;
+    }
+
+    public where($field, $value = '')
+    {
+        array_push($this->temp_select_where, $field, $value);
 
         return $this;
     }

--- a/app/Core/BaseModel.php
+++ b/app/Core/BaseModel.php
@@ -171,7 +171,7 @@ class BaseModel extends Model
         $params = func_get_args();
 
         if(empty($params)) {
-            throw new \UnexpectedValueException('The method must have parameters');
+            throw new \UnexpectedValueException('Method called without parameters');
         }
 
         if (count($params) == 1) {
@@ -242,20 +242,6 @@ class BaseModel extends Model
      */
     public function find_many_by()
     {
-        $where = func_get_args();
-
-        return $this->find_all($where);
-    }
-
-    /**
-     * Fetch all of the records in the table.
-     * Can be used with scoped calls to restrict the results.
-     *
-     * @return object or FALSE
-     */
-    public function find_all()
-    {
-        // Prepare the parameters.
         $params = func_get_args();
 
         if(empty($params)) {
@@ -268,7 +254,17 @@ class BaseModel extends Model
             $where = array($params[0] => $params[1]);
         }
 
-        //
+        return $this->find_all($where);
+    }
+
+    /**
+     * Fetch all of the records in the table.
+     * Can be used with scoped calls to restrict the results.
+     *
+     * @return object or FALSE
+     */
+    public function find_all($where = array())
+    {
         if(! is_array($where)) {
             throw new \UnexpectedValueException('Parameter should be an Array');
         }

--- a/app/Core/BaseModel.php
+++ b/app/Core/BaseModel.php
@@ -334,7 +334,7 @@ class BaseModel extends Model
      * @return object|array|null|false
      * @throws \Exception
      */
-    public function selectOne($sql, $bindParams = array(), $limit = false)
+    public function select_one($sql, $bindParams = array(), $limit = false)
     {
         return $this->select($sql, $bindParams, false, $limit);
     }
@@ -349,7 +349,7 @@ class BaseModel extends Model
      * @return array|null|false
      * @throws \Exception
      */
-    public function selectAll($sql, $bindParams = array(), $limit = false)
+    public function select_all($sql, $bindParams = array(), $limit = false)
     {
         return $this->select($sql, $bindParams, true, $limit);
     }

--- a/app/Core/BaseModel.php
+++ b/app/Core/BaseModel.php
@@ -174,7 +174,7 @@ class BaseModel extends Model
         //
         $this->trigger('before_find', ['method' => 'find_by', 'fields' => $where]);
 
-        $result = $this->db->select($sql, array(), true, $this->temp_return_type);
+        $result = $this->db->select($sql, $bindParams, false, $this->temp_return_type);
 
         if ( ! empty($result)) {
             $result = $this->trigger('after_find', array('method' => 'find_by', 'fields' => $result));

--- a/app/Core/BaseModel.php
+++ b/app/Core/BaseModel.php
@@ -144,11 +144,11 @@ class BaseModel extends Model
         $table = DB_PREFIX .$this->table_name;
 
         //
-        $this->trigger('before_find', ['id' => $id, 'method' => 'find']);
+        $this->trigger('before_find', array('id' => $id, 'method' => 'find'));
 
         $sql = "SELECT * FROM $table WHERE " .$this->primary_key ." = :param";
 
-        $result = $this->db->select($sql, array(), true, $this->temp_return_type);
+        $result = $this->db->select($sql, array('param' => $id), true, $this->temp_return_type);
 
         if ( ! empty($result)) {
             $result = $this->trigger('after_find', array('id' => $id, 'method' => 'find', 'fields' => $result));
@@ -180,7 +180,7 @@ class BaseModel extends Model
         $whereDetails = $this->whereDetails($where, $bindParams);
 
         // Prepare the SQL Query.
-        $sql = "SELECT * FROM $table WHERE $whereDetails;";
+        $sql = "SELECT * FROM $table $whereDetails;";
 
         //
         $this->trigger('before_find', array('method' => 'find_by', 'fields' => $where));

--- a/app/Core/BaseModel.php
+++ b/app/Core/BaseModel.php
@@ -353,11 +353,7 @@ class BaseModel extends Model
         $sql = "SELECT $fieldDetails FROM $table $whereDetails $limitDetails ";
 
         //
-        $data = $this->trigger('before_select', array(
-            'method' =>'select',
-            'where'  => $where,
-            'fields' => $fields
-        ));
+        $this->trigger('before_select', array('method' => 'select','where' => $where, 'fields' => $fields));
 
         $result = $this->db->select($sql, $bindParams, $fetchAll, $this->temp_return_type);
 
@@ -406,10 +402,7 @@ class BaseModel extends Model
 
     public function delete($where)
     {
-        $where = $this->trigger('before_delete', array(
-            'method' =>'delete',
-            'where'  => $where
-        ));
+        $this->trigger('before_delete', array('method' =>'delete', 'where' => $where));
 
         $result = $this->db->delete($this->table_name, $where);
 

--- a/app/Core/BaseModel.php
+++ b/app/Core/BaseModel.php
@@ -269,6 +269,8 @@ class BaseModel extends Model
      */
     public function find_all($where = array())
     {
+        $bindParams = array();
+
         // Get the TABLE name.
         $table = $this->table_name;
 

--- a/app/Core/BaseModel.php
+++ b/app/Core/BaseModel.php
@@ -126,6 +126,17 @@ class BaseModel extends Model
         $this->temp_return_type = $this->return_type;
     }
 
+    /**
+     * Finds a single record based on it's primary key.
+     *
+     * @param  mixed $id The primary_key value of the object to retrieve.
+     * @return object
+     */
+    public function find($id)
+    {
+        return $this->select('*', array($this->primary_key => $id), false);
+    }
+
     public function insert($data)
     {
         $data = $this->trigger('before_insert', array(

--- a/app/Core/BaseModel.php
+++ b/app/Core/BaseModel.php
@@ -274,6 +274,36 @@ class BaseModel extends Model
         return $result;
     }
 
+    /**
+     * Convenience method for fetching one record.
+     *
+     * @param string $sql
+     * @param array $bindParams
+     * @param null $method Customized method for fetching, null for engine default or config default.
+     * @param null $class Class for fetching into classes.
+     * @return object|array|null|false
+     * @throws \Exception
+     */
+    public function selectOne($sql, $bindParams = array())
+    {
+        return $this->select($sql, $bindParams, false);
+    }
+
+    /**
+     * Convenience method for fetching all records.
+     *
+     * @param string $sql
+     * @param array $bindParams
+     * @param null $method Customized method for fetching, null for engine default or config default.
+     * @param null $class Class for fetching into classes.
+     * @return array|null|false
+     * @throws \Exception
+     */
+    public function selectAll($sql, $bindParams = array())
+    {
+        return $this->select($sql, $bindParams, true);
+    }
+
     public function delete($where)
     {
         $where = $this->trigger('before_delete', array(

--- a/app/Core/BaseModel.php
+++ b/app/Core/BaseModel.php
@@ -167,17 +167,19 @@ class BaseModel extends Model
      */
     public function find_by()
     {
-        // Prepare the parameters.
+        // Prepare the WHERE parameters.
         $params = func_get_args();
 
-        if(empty($params)) {
-            throw new \UnexpectedValueException('Method called without parameters');
-        }
+        if(! empty($params)) {
+            $field = $params[0];
 
-        if (count($params) == 1) {
-            $where = array($params[0] => '');
-        } else {
-            $where = array($params[0] => $params[1]);
+            $value = isset($params[1]) ? $params[1] : '';
+
+            // Prepare the WHERE
+            $where = array($field => $value);
+        }
+        else {
+            throw new \UnexpectedValueException('Method called without parameters');
         }
 
         //
@@ -244,14 +246,16 @@ class BaseModel extends Model
     {
         $params = func_get_args();
 
-        if(empty($params)) {
-            $where = array();
-        }
-        else if (count($params) == 1) {
-            $where = array($params[0] => '');
+        if(! empty($params)) {
+            $field = $params[0];
+
+            $value = isset($params[1]) ? $params[1] : '';
+
+            // Prepare the WHERE
+            $where = array($field => $value);
         }
         else {
-            $where = array($params[0] => $params[1]);
+            throw new \UnexpectedValueException('Method called without parameters');
         }
 
         return $this->find_all($where);

--- a/app/Core/BaseModel.php
+++ b/app/Core/BaseModel.php
@@ -138,6 +138,24 @@ class BaseModel extends Model
         $this->temp_return_type = $this->return_type;
     }
 
+    //--------------------------------------------------------------------
+    // CRUD Methods
+    //--------------------------------------------------------------------
+
+    /**
+     * A simple way to grab the first result of a search only.
+     */
+    public function first()
+    {
+        $result = $this->limit(1, 0)->find_all();
+
+        if (is_array($result) && count($result)) {
+            return $result[0];
+        }
+
+        return $result;
+    }
+
     /**
      * Finds a single record based on it's primary key.
      *
@@ -183,7 +201,7 @@ class BaseModel extends Model
         $this->set_where($params);
 
         // Prepare the WHERE details.
-        $whereDetails = $this->whereDetails($this->temp_select_where, $bindParams);
+        $whereDetails = $this->where_details($this->temp_select_where, $bindParams);
 
         // Prepare the SQL Query.
         $sql = "SELECT * FROM " .$this->table() ." $whereDetails";
@@ -202,6 +220,9 @@ class BaseModel extends Model
 
         // Reset our select WHEREs
         $this->temp_select_where = array();
+
+        // Reset our select LIMITs
+        $this->temp_select_where = null;
 
         return $result;
     }
@@ -256,7 +277,7 @@ class BaseModel extends Model
         $bindParams = array();
 
         // Prepare the WHERE details.
-        $whereDetails = $this->whereDetails($this->temp_select_where, $bindParams);
+        $whereDetails = $this->where_details($this->temp_select_where, $bindParams);
 
         // Prepare the SQL Query.
         $sql = "SELECT * FROM " .$this->table() ." $whereDetails";
@@ -277,6 +298,9 @@ class BaseModel extends Model
 
         // Reset our select WHEREs
         $this->temp_select_where = array();
+
+        // Reset our select LIMITs
+        $this->temp_select_where = null;
 
         return $result;
     }
@@ -327,7 +351,7 @@ class BaseModel extends Model
         }
 
         // Prepare the WHERE details.
-        $whereDetails = $this->whereDetails($where, $bindParams);
+        $whereDetails = $this->where_details($where, $bindParams);
 
         // Prepare the LIMIT details.
         $limitDetails = '';
@@ -496,6 +520,13 @@ class BaseModel extends Model
     public where($field, $value = '')
     {
         array_push($this->temp_select_where, $field, $value);
+
+        return $this;
+    }
+
+    public limit($limit, $start = 0)
+    {
+        $this->temp_select_limit = array($start => $limit);
 
         return $this;
     }
@@ -711,6 +742,24 @@ class BaseModel extends Model
 
         if(! empty($result)) {
             $result = 'WHERE ' .$result;
+        }
+
+        return $result;
+    }
+
+    protected function limit_details($limits)
+    {
+        $result = '';
+
+        if(is_numeric($limits)) {
+            $result = '0, ' .$limits;
+        }
+        else if(is_array($limits)) {
+            $result = implode(', ', $limits);
+        }
+
+        if(! empty($result)) {
+            $result = 'LIMIT ' .$result;
         }
 
         return $result;

--- a/app/Core/BaseModel.php
+++ b/app/Core/BaseModel.php
@@ -140,13 +140,11 @@ class BaseModel extends Model
             throw new \UnexpectedValueException('Parameter should be an Integer');
         }
 
-        // Get the TABLE name.
-        $table = $this->table_name;
-
         //
         $this->trigger('before_find', array('id' => $id, 'method' => 'find'));
 
-        $sql = "SELECT * FROM $table WHERE " .$this->primary_key ." = :param";
+        // Prepare the SQL Query.
+        $sql = "SELECT * FROM " .$this->table_name ." WHERE " .$this->primary_key ." = :param";
 
         $result = $this->db->select($sql, array('param' => $id), true, $this->temp_return_type);
 
@@ -185,14 +183,11 @@ class BaseModel extends Model
         //
         $bindParams = array();
 
-        // Get the TABLE name.
-        $table = $this->table_name;
-
         // Prepare the WHERE details.
         $whereDetails = $this->whereDetails($where, $bindParams);
 
         // Prepare the SQL Query.
-        $sql = "SELECT * FROM $table $whereDetails";
+        $sql = "SELECT * FROM " .$this->table_name ." $whereDetails";
 
         //
         $this->trigger('before_find', array('method' => 'find_by', 'fields' => $where));
@@ -222,11 +217,8 @@ class BaseModel extends Model
             throw new \UnexpectedValueException('Parameter should be an Array');
         }
 
-        // Get the TABLE name.
-        $table = $this->table_name;
-
         // Prepare the SQL Query.
-        $sql = "SELECT * FROM $table WHERE " .$this->primary_key ." IN (".implode(',', $values) .")";
+        $sql = "SELECT * FROM " .$this->table_name ." WHERE " .$this->primary_key ." IN (".implode(',', $values) .")";
 
         //
         $result = $this->db->select($sql, array(), true, $this->temp_return_type);
@@ -271,14 +263,11 @@ class BaseModel extends Model
     {
         $bindParams = array();
 
-        // Get the TABLE name.
-        $table = $this->table_name;
-
         // Prepare the WHERE details.
         $whereDetails = $this->whereDetails($where, $bindParams);
 
         // Prepare the SQL Query.
-        $sql = "SELECT * FROM $table $whereDetails";
+        $sql = "SELECT * FROM " .$this->table_name ." $whereDetails";
 
         //
         $this->trigger('before_find', array('method' => 'find_all', 'fields' => $where));
@@ -332,9 +321,6 @@ class BaseModel extends Model
     {
         $bindParams = array();
 
-        // Get the TABLE name.
-        $table = $this->table_name;
-
         // Prepare the WHAT details.
         $fieldDetails = '*';
 
@@ -365,7 +351,7 @@ class BaseModel extends Model
         }
 
         // Prepare the SQL Query
-        $sql = "SELECT $fieldDetails FROM $table $whereDetails $limitDetails ";
+        $sql = "SELECT $fieldDetails FROM " .$this->table_name ." $whereDetails $limitDetails ";
 
         //
         $this->trigger('before_select', array('method' => 'select', 'where' => $where, 'fields' => $fields));

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -40,20 +40,20 @@ Config::set('database', array(
     'default' => array(
         'engine' => 'mysql',
         'config' => array(
-            'host'          => 'localhost',
-            'port'          => 3306, // Not required, default is 3306
-            'database'      => 'testdb1',
-            'username'      => 'root',
-            'password'      => '',
-            'fetch_method'  => \PDO::FETCH_OBJ, // Not required, default is OBJ.
-            'charset'       => 'utf8' // Not required, default and recommended is utf8.
+            'host'        => 'localhost',
+            'port'        => 3306,     // Not required, default is 3306
+            'database'    => 'testdb1',
+            'username'    => 'root',
+            'password'    => '',
+            'return_type' => 'object', // Not required, default is 'array'.
+            'charset'     => 'utf8'    // Not required, default and recommended is utf8.
         )
     ),
     'sqlite' => array(
         'engine' => 'sqlite',
         'config' => array(
-            'file'          => 'test.sqlite',
-            'fetch_method'  => \PDO::FETCH_OBJ // Not required, default is OBJ.
+            'file'        => 'test.sqlite',
+            'return_type' => 'object' // Not required, default is 'array'.
         )
     )
 ));

--- a/system/Database/Engine.php
+++ b/system/Database/Engine.php
@@ -28,9 +28,9 @@ interface Engine
     public function getDriverCode();
 
     /**
-     * Set/Get the current fetching Method
+     * Set/Get the fetching return type.
      */
-    public function fetchMethod();
+    public function returnType();
 
     /**
      * Get configuration for instance
@@ -63,6 +63,7 @@ interface Engine
      * @return mixed
      */
     public function raw($sql, $fetch = false);
+    
     public function rawQuery($sql);
 
 
@@ -79,7 +80,7 @@ interface Engine
      *
      * @throws \Exception
      */
-    public function select($sql, $bindParams = array(), $fetchAll = false, $method = null, $class = null);
+    public function select($sql, $bindParams = array(), $fetchAll = false, $returnType = null);
 
     /**
      * Convenience methods for selecting records.
@@ -92,8 +93,8 @@ interface Engine
      *
      * @throws \Exception
      */
-    public function selectOne($sql, $bindParams = array(), $method = null, $class = null);
-    public function selectAll($sql, $bindParams = array(), $method = null, $class = null);
+    public function selectOne($sql, $bindParams = array(), $returnType = null);
+    public function selectAll($sql, $bindParams = array(), $returnType = null);
 
     /**
      * Execute insert query, will automatically build query for you.

--- a/system/Database/Engine/Base.php
+++ b/system/Database/Engine/Base.php
@@ -40,7 +40,7 @@ abstract class Base extends \PDO implements Engine
         }
 
         // Will set the default method when provided in the config.
-        if (isset($config['fetch_method'])) {
+        if (isset($config['return_type'])) {
             $this->returnType = $config['return_type'];
         }
 

--- a/system/Database/Engine/Base.php
+++ b/system/Database/Engine/Base.php
@@ -53,7 +53,7 @@ abstract class Base extends \PDO implements Engine
         else {
             $classPath = str_replace('\\', '/', $this->returnType);
 
-            if(preg_match('#^App(?:/Modules/.+)?/Models/Entities/(.*)$#i', $classPath)) {
+            if(! preg_match('#^App(?:/Modules/.+)?/Models/Entities/(.*)$#i', $classPath)) {
                 throw new \Exception("No valid Entity is given.");
             }
 
@@ -187,7 +187,7 @@ abstract class Base extends \PDO implements Engine
         else {
             $classPath = str_replace('\\', '/', $returnType);
 
-            if(preg_match('#^App(?:/Modules/.+)?/Models/Entities/(.*)$#i', $classPath)) {
+            if(! preg_match('#^App(?:/Modules/.+)?/Models/Entities/(.*)$#i', $classPath)) {
                 throw new \Exception("No valid Entity is given.");
             }
 

--- a/system/Database/Engine/Base.php
+++ b/system/Database/Engine/Base.php
@@ -16,8 +16,8 @@ use Nova\Database\Manager;
 
 abstract class Base extends \PDO implements Engine
 {
-    /** @var int PDO Fetch method. */
-    protected $method = \PDO::FETCH_ASSOC;
+    /** @var string Return type. */
+    protected $returnType = 'array';
 
     /** @var array Config from the user's app config. */
     protected $config;
@@ -41,7 +41,23 @@ abstract class Base extends \PDO implements Engine
 
         // Will set the default method when provided in the config.
         if (isset($config['fetch_method'])) {
-            $this->method = $config['fetch_method'];
+            $this->returnType = $config['return_type'];
+        }
+
+        if($this->returnType == 'array') {
+            $fetchMethod = \PDO::FETCH_ASSOC;
+        }
+        else if($this->returnType == 'object') {
+            $fetchMethod = \PDO::FETCH_OBJ;
+        }
+        else {
+            $classPath = str_replace('\\', '/', $this->returnType);
+
+            if(preg_match('#^App(?:/Modules/.+)?/Models/Entities/(.*)$#i', $classPath)) {
+                throw new \Exception("No valid Entity is given.");
+            }
+
+            $fetchMethod = \PDO::FETCH_CLASS;
         }
 
         // Store the config in class variable.
@@ -55,7 +71,7 @@ abstract class Base extends \PDO implements Engine
         parent::__construct($dsn, $username, $password, $options);
 
         $this->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
-        $this->setAttribute(\PDO::ATTR_DEFAULT_FETCH_MODE, $this->method);
+        $this->setAttribute(\PDO::ATTR_DEFAULT_FETCH_MODE, $fetchMethod);
     }
 
     /**
@@ -71,15 +87,15 @@ abstract class Base extends \PDO implements Engine
     abstract public function getDriverCode();
 
     /**
-     * Set/Get the current fetching Method
+     * Set/Get the fetching return type.
      */
-    public function fetchMethod($method = null)
+    public function returnType($type = null)
     {
-        if($method === null) {
-            return $this->method;
+        if($type === null) {
+            return $this->returnType;
         }
 
-        $this->method = $method;
+        $this->returnType = $type;
     }
 
     /**
@@ -111,12 +127,8 @@ abstract class Base extends \PDO implements Engine
      */
     public function raw($sql, $fetch = false)
     {
-        $method = $this->method;
-
-        if ($this->method === \PDO::FETCH_CLASS) {
-            // We can't fetch class here to stay conform the interface, make it OBJ for this simple query.
-            $method = \PDO::FETCH_OBJ;
-        }
+        // We can't fetch class here to stay conform the interface, make it OBJ for this simple query.
+        $method = ($this->returnType == 'array') ? \PDO::FETCH_ASSOC : \PDO::FETCH_OBJ;
 
         $this->queryCount++;
 
@@ -132,7 +144,7 @@ abstract class Base extends \PDO implements Engine
     public function rawQuery($sql)
     {
         // We can't fetch class here to stay conform the interface, make it OBJ for this simple query.
-        $method = ($this->method !== \PDO::FETCH_CLASS) ? $this->method : \PDO::FETCH_OBJ;
+        $method = ($this->returnType == 'array') ? \PDO::FETCH_ASSOC : \PDO::FETCH_OBJ;
 
         $this->queryCount++;
 
@@ -153,16 +165,35 @@ abstract class Base extends \PDO implements Engine
      *
      * @throws \Exception
      */
-    public function select($sql, $bindParams = array(), $fetchAll = false, $method = null, $class = null)
+    public function select($sql, $bindParams = array(), $fetchAll = false, $returnType = null)
     {
         // Append select if it isn't appended.
         if (strtolower(substr($sql, 0, 7)) !== 'select ') {
             $sql = "SELECT " . $sql;
         }
 
-        // What method? Use default if no method is given my the call.
-        if ($method === null) {
-            $method = $this->method;
+        // What return type? Use default if no return type is given in the call.
+        $returnType = $returnType ? $returnType : $this->returnType;
+
+        // Prepare the parameters.
+        $className = null;
+
+        if($returnType == 'array') {
+            $fetchMethod = \PDO::FETCH_ASSOC;
+        }
+        else if($returnType == 'object') {
+            $fetchMethod = \PDO::FETCH_OBJ;
+        }
+        else {
+            $classPath = str_replace('\\', '/', $returnType);
+
+            if(preg_match('#^App(?:/Modules/.+)?/Models/Entities/(.*)$#i', $classPath)) {
+                throw new \Exception("No valid Entity is given.");
+            }
+
+            $className = $returnType;
+
+            $fetchMethod = \PDO::FETCH_CLASS;
         }
 
         // Prepare and get statement from PDO.
@@ -189,16 +220,12 @@ abstract class Base extends \PDO implements Engine
 
         if($fetchAll) {
             // Continue with fetching all records.
-            if ($method === \PDO::FETCH_CLASS) {
-                if (!$class) {
-                    throw new \Exception("No Class is given while using the PDO::FETCH_CLASS method.");
-                }
-
+            if ($fetchMethod === \PDO::FETCH_CLASS) {
                 // Fetch in class
-                $result = $stmt->fetchAll($method, $class);
+                $result = $stmt->fetchAll($fetchMethod, $className);
             }
             else {
-                $result = $stmt->fetchAll($method);
+                $result = $stmt->fetchAll($fetchMethod);
             }
 
             if (is_array($result) && count($result) > 0) {
@@ -209,16 +236,12 @@ abstract class Base extends \PDO implements Engine
         }
 
         // Continue with fetching one record.
-        if ($method === \PDO::FETCH_CLASS) {
-            if (!$class) {
-                throw new \Exception("No Class is given while using the PDO::FETCH_CLASS method.");
-            }
-
+        if ($fetchMethod === \PDO::FETCH_CLASS) {
             // Fetch in class
-            return $stmt->fetch($method, $class);
+            return $stmt->fetch($fetchMethod, $className);
         }
         else {
-            return $stmt->fetch($method);
+            return $stmt->fetch($fetchMethod);
         }
     }
 
@@ -232,9 +255,9 @@ abstract class Base extends \PDO implements Engine
      * @return object|array|null|false
      * @throws \Exception
      */
-    public function selectOne($sql, $bindParams = array(), $method = null, $class = null)
+    public function selectOne($sql, $bindParams = array(), $returnType = null)
     {
-        return $this->select($sql, $bindParams, false, $method, $class);
+        return $this->select($sql, $bindParams, false, $returnType);
     }
 
     /**
@@ -247,9 +270,9 @@ abstract class Base extends \PDO implements Engine
      * @return array|null|false
      * @throws \Exception
      */
-    public function selectAll($sql, $bindParams = array(), $method = null, $class = null)
+    public function selectAll($sql, $bindParams = array(), $returnType = null)
     {
-        return $this->select($sql, $bindParams, true, $method, $class);
+        return $this->select($sql, $bindParams, true, $returnType);
     }
 
     /**

--- a/system/Database/Service.php
+++ b/system/Database/Service.php
@@ -133,7 +133,7 @@ abstract class Service extends CoreService
             throw new \Exception("No fetchClass is given while calling READ method");
         }
 
-        return $this->engine->selectAll($sql, $bindParams, \PDO::FETCH_CLASS, $this->fetchClass);
+        return $this->engine->selectAll($sql, $bindParams, $this->fetchClass);
     }
 
     /**

--- a/tests/Nova/Database/Engine/MySQLEngineTest.php
+++ b/tests/Nova/Database/Engine/MySQLEngineTest.php
@@ -24,7 +24,7 @@ class MySQLEngineTest extends \PHPUnit_Framework_TestCase
     {
         $this->engine = \Nova\Database\Manager::getEngine();
 
-        $this->engine->fetchMethod(\PDO::FETCH_OBJ);
+        $this->engine->returnType('object');
 
         $this->assertInstanceOf('\Nova\Database\Engine\MySQL', $this->engine);
     }
@@ -64,7 +64,7 @@ class MySQLEngineTest extends \PHPUnit_Framework_TestCase
         // === Select All, No WHERE.
 
         // First, we will get ALL our cars, we will use the selectAll
-        $all = $this->engine->selectAll("SELECT * FROM " . DB_PREFIX . "car");
+        $all = $this->engine->selectAll("SELECT * FROM " .DB_PREFIX ."car");
 
         $this->assertGreaterThanOrEqual(2, count($all), "Select should return array of 2 or more");
 
@@ -76,7 +76,7 @@ class MySQLEngineTest extends \PHPUnit_Framework_TestCase
 
 
         // === Select One, Only get the Model S
-        $model_s = $this->engine->selectOne("SELECT * FROM " . DB_PREFIX . "car WHERE model LIKE 'Model S';");
+        $model_s = $this->engine->selectOne("SELECT * FROM " .DB_PREFIX ."car WHERE model LIKE 'Model S';");
 
         $this->assertNotNull($model_s);
         $this->assertObjectHasAttribute('carid', $model_s);
@@ -89,7 +89,7 @@ class MySQLEngineTest extends \PHPUnit_Framework_TestCase
 
 
         // === Select All, Fetch With ASSOC
-        $all_assoc = $this->engine->selectAll("SELECT * FROM " . DB_PREFIX . "car", array(), \PDO::FETCH_ASSOC);
+        $all_assoc = $this->engine->selectAll("SELECT * FROM " .DB_PREFIX ."car", array(), 'array');
 
         $this->assertGreaterThanOrEqual(2, count($all_assoc), "Select should return array of 2 or more");
 
@@ -102,7 +102,7 @@ class MySQLEngineTest extends \PHPUnit_Framework_TestCase
 
 
         // === Select One, But this doesn't exists.
-        $notthere = $this->engine->selectOne("SELECT * FROM " . DB_PREFIX . "car WHERE make LIKE 'Renault';");
+        $notthere = $this->engine->selectOne("SELECT * FROM " .DB_PREFIX ."car WHERE make LIKE 'Renault';");
 
         $this->assertFalse($notthere);
     }
@@ -122,7 +122,7 @@ class MySQLEngineTest extends \PHPUnit_Framework_TestCase
 
         // === Single insert
         $data_1 = array('make' => 'Nova Cars', 'model' => 'FrameworkCar_1', 'costs' => 18000);
-        $insert_1 = $this->engine->insert(DB_PREFIX . 'car', $data_1);
+        $insert_1 = $this->engine->insert(DB_PREFIX .'car', $data_1);
 
         $this->assertNotFalse($insert_1);
         $this->assertGreaterThan(2, $insert_1);
@@ -143,7 +143,7 @@ class MySQLEngineTest extends \PHPUnit_Framework_TestCase
             array('make' => 'Nova Cars', 'model' => 'FrameworkCar_3', 'costs' => 38000),
             array('make' => 'Nova Cars', 'model' => 'FrameworkCar_4', 'costs' => 48000)
         );
-        $insert_2 = $this->engine->insertBatch(DB_PREFIX . 'car', $data_2, false);
+        $insert_2 = $this->engine->insertBatch(DB_PREFIX .'car', $data_2, false);
 
         $this->assertEquals(3, count($insert_2));
         foreach($insert_2 as $key => $value) {
@@ -157,7 +157,7 @@ class MySQLEngineTest extends \PHPUnit_Framework_TestCase
             array('make' => 'Nova Cars', 'model' => 'FrameworkCar_6', 'costs' => 31000),
             array('make' => 'Nova Cars', 'model' => 'FrameworkCar_7', 'costs' => 41000)
         );
-        $insert_3 = $this->engine->insertBatch(DB_PREFIX . 'car', $data_3, true);
+        $insert_3 = $this->engine->insertBatch(DB_PREFIX .'car', $data_3, true);
 
         $this->assertEquals(3, count($insert_3));
         foreach($insert_3 as $key => $value) {
@@ -173,20 +173,20 @@ class MySQLEngineTest extends \PHPUnit_Framework_TestCase
         );
 
         try {
-            $this->engine->insertBatch(DB_PREFIX . 'car', $data_4, true);
+            $this->engine->insertBatch(DB_PREFIX .'car', $data_4, true);
             $this->assertFalse(true, 'Inserting error data should give exceptions!');
         }catch(\Exception $e) {
             $this->assertContains("null", $e->getMessage());
         }
 
         // Check if the other one is still inserted!
-        $wronginserted = $this->engine->selectAll("SELECT * FROM " . DB_PREFIX . "car WHERE model LIKE 'FrameworkCar_9';");
+        $wronginserted = $this->engine->selectAll("SELECT * FROM " .DB_PREFIX ."car WHERE model LIKE 'FrameworkCar_9';");
 
         // Should be false!
         $this->assertFalse($wronginserted, 'Transaction inserts should rollback after detecting errors!');
 
         // Cleanup all our test cars
-        $this->engine->rawQuery("DELETE FROM " . DB_PREFIX . "car WHERE make LIKE 'Nova Cars';");
+        $this->engine->rawQuery("DELETE FROM " .DB_PREFIX ."car WHERE make LIKE 'Nova Cars';");
         $this->engine->commit();
     }
 
@@ -205,18 +205,18 @@ class MySQLEngineTest extends \PHPUnit_Framework_TestCase
 
         // === Will add our test car fist, We will edit this one a few times
         $data = array('make' => 'Nova Cars', 'model' => 'FrameworkCar_Update_1', 'costs' => 18000);
-        $id = $this->engine->insert(DB_PREFIX . 'car', $data);
+        $id = $this->engine->insert(DB_PREFIX .'car', $data);
 
         $this->assertGreaterThanOrEqual(2, $id);
 
         // === Basic simple update
         $data_update_1 = array('costs' => 20000);
-        $update_1 = $this->engine->update(DB_PREFIX . 'car', $data_update_1, array('carid' => $id));
+        $update_1 = $this->engine->update(DB_PREFIX .'car', $data_update_1, array('carid' => $id));
 
         $this->assertNotFalse($update_1);
 
         // Test if it's changed
-        $result_1 = $this->engine->selectOne("SELECT * FROM " . DB_PREFIX . "car WHERE carid = :carid", array('carid' => $id));
+        $result_1 = $this->engine->selectOne("SELECT * FROM " .DB_PREFIX ."car WHERE carid = :carid", array('carid' => $id));
 
         $this->assertNotNull($result_1);
         $this->assertObjectHasAttribute('carid', $result_1);
@@ -229,7 +229,7 @@ class MySQLEngineTest extends \PHPUnit_Framework_TestCase
 
 
         // Cleanup
-        $this->engine->rawQuery("DELETE FROM " . DB_PREFIX . "car WHERE make LIKE 'Nova Cars';");
+        $this->engine->rawQuery("DELETE FROM " .DB_PREFIX ."car WHERE make LIKE 'Nova Cars';");
     }
 
     /**
@@ -245,29 +245,29 @@ class MySQLEngineTest extends \PHPUnit_Framework_TestCase
 
         // === Basic test by inserting and deleting several records
         $data_1 = array('make' => 'Nova Cars', 'model' => 'FrameworkCar_Delete_1', 'costs' => 18000);
-        $id_1 = $this->engine->insert(DB_PREFIX . 'car', $data_1);
+        $id_1 = $this->engine->insert(DB_PREFIX .'car', $data_1);
 
         $data_2 = array('make' => 'Nova Cars', 'model' => 'FrameworkCar_Delete_2', 'costs' => 18000);
-        $id_2 = $this->engine->insert(DB_PREFIX . 'car', $data_2);
+        $id_2 = $this->engine->insert(DB_PREFIX .'car', $data_2);
 
         $data_3 = array('make' => 'Nova Cars', 'model' => 'FrameworkCar_Delete_3', 'costs' => 99999);
-        $id_3 = $this->engine->insert(DB_PREFIX . 'car', $data_3);
+        $id_3 = $this->engine->insert(DB_PREFIX .'car', $data_3);
 
         $this->assertGreaterThanOrEqual(2, $id_1);
         $this->assertGreaterThanOrEqual(2, $id_2);
         $this->assertGreaterThanOrEqual(2, $id_3);
 
         // Delete all 3 with several styles
-        $delete_1 = $this->engine->delete(DB_PREFIX . 'car', array('carid' => $id_1));
-        $delete_2 = $this->engine->delete(DB_PREFIX . 'car', array('model' => 'FrameworkCar_Delete_2'));
-        $delete_3 = $this->engine->delete(DB_PREFIX . 'car', array('costs' => 99999));
+        $delete_1 = $this->engine->delete(DB_PREFIX .'car', array('carid' => $id_1));
+        $delete_2 = $this->engine->delete(DB_PREFIX .'car', array('model' => 'FrameworkCar_Delete_2'));
+        $delete_3 = $this->engine->delete(DB_PREFIX .'car', array('costs' => 99999));
 
         $this->assertNotFalse($delete_1);
         $this->assertNotFalse($delete_2);
         $this->assertNotFalse($delete_3);
 
         // Check if we still can find the inserted records
-        $sql = "SELECT * FROM " . DB_PREFIX . "car WHERE carid = :carid1 OR carid = :carid2 OR carid = :carid3;";
+        $sql = "SELECT * FROM " .DB_PREFIX ."car WHERE carid = :carid1 OR carid = :carid2 OR carid = :carid3;";
         $all = $this->engine->selectAll($sql, array('carid1' => $id_1,'carid2' => $id_2,'carid3' => $id_3));
 
         // Should be empty => false.

--- a/tests/Nova/Database/Engine/SQLiteEngineTest.php
+++ b/tests/Nova/Database/Engine/SQLiteEngineTest.php
@@ -24,7 +24,7 @@ class SQLiteEngineTest extends \PHPUnit_Framework_TestCase
     {
         $this->engine = \Nova\Database\Manager::getEngine('sqlite');
 
-        $this->engine->fetchMethod(\PDO::FETCH_OBJ);
+        $this->engine->returnType('object');
 
         $this->assertInstanceOf('\Nova\Database\Engine\SQLite', $this->engine);
     }
@@ -64,7 +64,7 @@ class SQLiteEngineTest extends \PHPUnit_Framework_TestCase
         // === Select All, No WHERE.
 
         // First, we will get ALL our cars, we will use the selectAll
-        $all = $this->engine->selectAll("SELECT * FROM " . DB_PREFIX . "car");
+        $all = $this->engine->selectAll("SELECT * FROM " .DB_PREFIX ."car");
 
         $this->assertGreaterThanOrEqual(2, count($all), "Select should return array of 2 or more");
 
@@ -76,7 +76,7 @@ class SQLiteEngineTest extends \PHPUnit_Framework_TestCase
 
 
         // === Select One, Only get the Model S
-        $model_s = $this->engine->selectOne("SELECT * FROM " . DB_PREFIX . "car WHERE model LIKE 'Model S';");
+        $model_s = $this->engine->selectOne("SELECT * FROM " .DB_PREFIX ."car WHERE model LIKE 'Model S';");
 
         $this->assertNotNull($model_s);
         $this->assertObjectHasAttribute('carid', $model_s);
@@ -89,7 +89,7 @@ class SQLiteEngineTest extends \PHPUnit_Framework_TestCase
 
 
         // === Select All, Fetch With ASSOC
-        $all_assoc = $this->engine->selectAll("SELECT * FROM " . DB_PREFIX . "car", array(), \PDO::FETCH_ASSOC);
+        $all_assoc = $this->engine->selectAll("SELECT * FROM " .DB_PREFIX ."car", array(), 'array');
 
         $this->assertGreaterThanOrEqual(2, count($all_assoc), "Select should return array of 2 or more");
 
@@ -102,7 +102,7 @@ class SQLiteEngineTest extends \PHPUnit_Framework_TestCase
 
 
         // === Select One, But this doesn't exists.
-        $notthere = $this->engine->selectOne("SELECT * FROM " . DB_PREFIX . "car WHERE make LIKE 'Renault';");
+        $notthere = $this->engine->selectOne("SELECT * FROM " .DB_PREFIX ."car WHERE make LIKE 'Renault';");
 
         $this->assertFalse($notthere);
     }
@@ -123,7 +123,7 @@ class SQLiteEngineTest extends \PHPUnit_Framework_TestCase
 
         // === Single insert
         $data_1 = array('make' => 'Nova Cars', 'model' => 'FrameworkCar_1', 'costs' => 18000);
-        $insert_1 = $this->engine->insert(DB_PREFIX . 'car', $data_1);
+        $insert_1 = $this->engine->insert(DB_PREFIX .'car', $data_1);
 
         $this->assertNotFalse($insert_1);
         $this->assertGreaterThan(2, $insert_1);
@@ -144,7 +144,7 @@ class SQLiteEngineTest extends \PHPUnit_Framework_TestCase
             array('make' => 'Nova Cars', 'model' => 'FrameworkCar_3', 'costs' => 38000),
             array('make' => 'Nova Cars', 'model' => 'FrameworkCar_4', 'costs' => 48000)
         );
-        $insert_2 = $this->engine->insertBatch(DB_PREFIX . 'car', $data_2, false);
+        $insert_2 = $this->engine->insertBatch(DB_PREFIX .'car', $data_2, false);
 
         $this->assertEquals(3, count($insert_2));
         foreach($insert_2 as $key => $value) {
@@ -158,7 +158,7 @@ class SQLiteEngineTest extends \PHPUnit_Framework_TestCase
             array('make' => 'Nova Cars', 'model' => 'FrameworkCar_6', 'costs' => 31000),
             array('make' => 'Nova Cars', 'model' => 'FrameworkCar_7', 'costs' => 41000)
         );
-        $insert_3 = $this->engine->insertBatch(DB_PREFIX . 'car', $data_3, true);
+        $insert_3 = $this->engine->insertBatch(DB_PREFIX .'car', $data_3, true);
 
         $this->assertEquals(3, count($insert_3));
         foreach($insert_3 as $key => $value) {
@@ -174,20 +174,20 @@ class SQLiteEngineTest extends \PHPUnit_Framework_TestCase
         );
 
         try {
-            $this->engine->insertBatch(DB_PREFIX . 'car', $data_4, true);
+            $this->engine->insertBatch(DB_PREFIX .'car', $data_4, true);
             $this->assertFalse(true, 'Inserting error data should give exceptions!');
         }catch(\Exception $e) {
             $this->assertContains("NULL", $e->getMessage());
         }
 
         // Check if the other one is still inserted!
-        $wronginserted = $this->engine->selectAll("SELECT * FROM " . DB_PREFIX . "car WHERE model LIKE 'FrameworkCar_9';");
+        $wronginserted = $this->engine->selectAll("SELECT * FROM " .DB_PREFIX ."car WHERE model LIKE 'FrameworkCar_9';");
 
         // Should be false!
         $this->assertFalse($wronginserted, 'Transaction inserts should rollback after detecting errors!');
 
         // Cleanup all our test cars
-        $this->engine->rawQuery("DELETE FROM " . DB_PREFIX . "car WHERE make LIKE 'Nova Cars';");
+        $this->engine->rawQuery("DELETE FROM " .DB_PREFIX ."car WHERE make LIKE 'Nova Cars';");
         $this->engine->commit();
     }
 
@@ -206,18 +206,18 @@ class SQLiteEngineTest extends \PHPUnit_Framework_TestCase
 
         // === Will add our test car fist, We will edit this one a few times
         $data = array('make' => 'Nova Cars', 'model' => 'FrameworkCar_Update_1', 'costs' => 18000);
-        $id = $this->engine->insert(DB_PREFIX . 'car', $data);
+        $id = $this->engine->insert(DB_PREFIX .'car', $data);
 
         $this->assertGreaterThanOrEqual(2, $id);
 
         // === Basic simple update
         $data_update_1 = array('costs' => 20000);
-        $update_1 = $this->engine->update(DB_PREFIX . 'car', $data_update_1, array('carid' => $id));
+        $update_1 = $this->engine->update(DB_PREFIX .'car', $data_update_1, array('carid' => $id));
 
         $this->assertNotFalse($update_1);
 
         // Test if it's changed
-        $result_1 = $this->engine->selectOne("SELECT * FROM " . DB_PREFIX . "car WHERE carid = :carid", array('carid' => $id));
+        $result_1 = $this->engine->selectOne("SELECT * FROM " .DB_PREFIX ."car WHERE carid = :carid", array('carid' => $id));
 
         $this->assertNotNull($result_1);
         $this->assertObjectHasAttribute('carid', $result_1);
@@ -228,7 +228,7 @@ class SQLiteEngineTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(20000, $result_1->costs);
 
         // Cleanup
-        $this->engine->rawQuery("DELETE FROM " . DB_PREFIX . "car WHERE make LIKE 'Nova Cars';");
+        $this->engine->rawQuery("DELETE FROM " .DB_PREFIX ."car WHERE make LIKE 'Nova Cars';");
     }
 
 
@@ -245,29 +245,29 @@ class SQLiteEngineTest extends \PHPUnit_Framework_TestCase
 
         // === Basic test by inserting and deleting several records
         $data_1 = array('make' => 'Nova Cars', 'model' => 'FrameworkCar_Delete_1', 'costs' => 18000);
-        $id_1 = $this->engine->insert(DB_PREFIX . 'car', $data_1);
+        $id_1 = $this->engine->insert(DB_PREFIX .'car', $data_1);
 
         $data_2 = array('make' => 'Nova Cars', 'model' => 'FrameworkCar_Delete_2', 'costs' => 18000);
-        $id_2 = $this->engine->insert(DB_PREFIX . 'car', $data_2);
+        $id_2 = $this->engine->insert(DB_PREFIX .'car', $data_2);
 
         $data_3 = array('make' => 'Nova Cars', 'model' => 'FrameworkCar_Delete_3', 'costs' => 99999);
-        $id_3 = $this->engine->insert(DB_PREFIX . 'car', $data_3);
+        $id_3 = $this->engine->insert(DB_PREFIX .'car', $data_3);
 
         $this->assertGreaterThanOrEqual(2, $id_1);
         $this->assertGreaterThanOrEqual(2, $id_2);
         $this->assertGreaterThanOrEqual(2, $id_3);
 
         // Delete all 3 with several styles
-        $delete_1 = $this->engine->delete(DB_PREFIX . 'car', array('carid' => $id_1));
-        $delete_2 = $this->engine->delete(DB_PREFIX . 'car', array('model' => 'FrameworkCar_Delete_2'));
-        $delete_3 = $this->engine->delete(DB_PREFIX . 'car', array('costs' => 99999));
+        $delete_1 = $this->engine->delete(DB_PREFIX .'car', array('carid' => $id_1));
+        $delete_2 = $this->engine->delete(DB_PREFIX .'car', array('model' => 'FrameworkCar_Delete_2'));
+        $delete_3 = $this->engine->delete(DB_PREFIX .'car', array('costs' => 99999));
 
         $this->assertNotFalse($delete_1);
         $this->assertNotFalse($delete_2);
         $this->assertNotFalse($delete_3);
 
         // Check if we still can find the inserted records
-        $sql = "SELECT * FROM " . DB_PREFIX . "car WHERE carid = :carid1 OR carid = :carid2 OR carid = :carid3;";
+        $sql = "SELECT * FROM " .DB_PREFIX ."car WHERE carid = :carid1 OR carid = :carid2 OR carid = :carid3;";
         $all = $this->engine->selectAll($sql, array('carid1' => $id_1,'carid2' => $id_2,'carid3' => $id_3));
 
         // Should be empty => false.


### PR DESCRIPTION
Simplify the logic of Database Engines, permitting to configure the fetching return type with a single parameter instead of two.

The new parameter is **returnType**, with the following possible values:

**array** is equivalent with passing **PDO::FETCH_ARRAY**
**object** is equivalent with passing **PDO::FETCH_OBJ**
**className** is equivalent with passing **PDO::FETCH_CLASS** and to fetch a valid qualified a **Entity**, defined by a qualified Class Name (full namespace).

Also, in this pull-request is continued the work on **\App\Core\BaseModel** and new methods are implemented.