### PR TITLE
Disable the numeric index binding into \Nova\Database\Connection beca…

### DIFF
--- a/system/Database/Connection.php
+++ b/system/Database/Connection.php
@@ -178,9 +178,12 @@ abstract class Connection extends PDO
         // Bind the key and values (only if given).
         foreach ($params as $key => $value) {
             $bindKey = $prefix .$key;
-            if (is_int($key)) {
-                $bindKey = $key+1;
-            }
+            // Disable for now the numeric binding, as will result into wrong bindings when there are
+            // multiple calls of this method, for example in the method 'update'.
+
+            //if (is_int($key)) {
+            //    $bindKey = $key+1;
+            //}
 
             if(isset($paramTypes[$key])) {
                 $statement->bindValue($bindKey, $value, $paramTypes[$key]);


### PR DESCRIPTION
…use of possible incorrect index calculation when there are multiple calls. For example, into **\Nova\Connection::update** method will result into:

### First call

```php
        // Bind fields
        $this->bindParams($stmt, $data, $paramTypes, ':field_');
```

will result into binding of 

```
$statement->bindValue(1, 'admin', PDO::PARAM_STR);
```

### Second call

```php
        // Bind values
        $this->bindParams($stmt, $bindParams, $paramTypes);
```

will result into binding of 

```
$statement->bindValue(1, 1, PDO::PARAM_INT);
```

### Resulted SQL statement

```sql

UPDATE users SET username=1 WHERE id=1"
```
