### PR TITLE
Improve Nova\ORM and update the associated Demos and SQL file

### DIFF
--- a/app/Core/ClassicController.php
+++ b/app/Core/ClassicController.php
@@ -53,7 +53,7 @@ class ClassicController extends BaseController
         }
 
         if (($result === true) || is_null($result)) {
-            $data =& $this->data();
+            $data = $this->data();
 
             if ($this->useLayout) {
                 $content = View::renderView($this->method(), $data, true);

--- a/app/Core/ThemedController.php
+++ b/app/Core/ThemedController.php
@@ -53,7 +53,7 @@ class ThemedController extends BaseController
         }
 
         if (($result === true) || is_null($result)) {
-            $data =& $this->data();
+            $data = $this->data();
 
             if ($this->useLayout) {
                 $content = View::make($this->method())

--- a/app/Modules/Demo/Controllers/Models/RelationalModel.php
+++ b/app/Modules/Demo/Controllers/Models/RelationalModel.php
@@ -11,7 +11,14 @@ namespace App\Modules\Demo\Controllers\Models;
 
 use Nova\Core\View;
 use App\Modules\Demo\Core\BaseController;
+
 use App\Modules\Demo\Models\User;
+use App\Modules\Demo\Models\Profile;
+use App\Modules\Demo\Models\Post;
+use App\Modules\Demo\Models\Student;
+use App\Modules\Demo\Models\Course;
+
+use Nova\ORM\Model as BaseModel;
 
 use \PDO;
 
@@ -193,6 +200,149 @@ var_dump(\$result);
         $message .= '<pre>'. $this->model->lastSqlQuery().'</pre>';
         $message .= '<pre>'. self::dumpObjectArray($result).'</pre><br>';
 
+        //
+        $message .= '<h3><strong>'.__d('demo', 'Relations: hasOne').'</strong></h3><br>';
+
+        //
+        $user = $this->model->findBy('username', 'marcus');
+
+        $profile = $user->profile()->get();
+
+        $text = "
+\$user = \$this->model->findBy('username', 'marcus');
+
+\$profile = \$user->profile
+
+self::dumpObject(\$user);
+self::dumpObject(\$profile);
+self::dumpObject(\$user->profile);
+        ";
+
+        $message .= self::highlightText($text, true);
+        $message .= '<pre>'. self::dumpObject($user).'</pre>';
+        $message .= '<pre>'. self::dumpObject($profile).'</pre>';
+        $message .= '<pre>'. self::dumpObject($user->profile).'</pre><br>';
+
+        //
+        $message .= '<h3><strong>'.__d('demo', 'Relations: belongsTo').'</strong></h3><br>';
+
+        //
+        $user = $this->model->findBy('username', 'marcus');
+
+        $profile = $user->profile;
+
+        $user2 = $profile->user;
+
+        $text = "
+\$user = \$this->model->findBy('username', 'marcus');
+
+\$profile = \$user->profile
+
+\$user2 = \$profile->user;
+
+self::dumpObject(\$user);
+self::dumpObject(\$profile);
+self::dumpObject(\$user2);
+        ";
+
+        $message .= self::highlightText($text, true);
+        $message .= '<pre>'. self::dumpObject($user).'</pre>';
+        $message .= '<pre>'. self::dumpObject($profile).'</pre>';
+        $message .= '<pre>'. self::dumpObject($user2).'</pre><br>';
+
+        //
+        $model = new Post();
+
+        $post = $model->find(1);
+
+        $author = $post->author;
+
+        $text = "
+\$model = new Post();
+
+\$post = \$model->find(1);
+
+\$author = \$post->author;
+
+self::dumpObject(\$post);
+self::dumpObject(\$author);
+        ";
+
+        $message .= self::highlightText($text, true);
+        $message .= '<pre>'. self::dumpObject($post).'</pre>';
+        $message .= '<pre>'. self::dumpObject($author).'</pre><br>';
+
+        //
+        $message .= '<h3><strong>'.__d('demo', 'Relations: hasMany').'</strong></h3><br>';
+
+        //
+        $user = $this->model->findBy('username', 'marcus');
+
+        $posts = $user->posts;
+
+        $text = "
+\$user = \$this->model->findBy('username', 'marcus');
+
+\$posts = \$user->posts
+
+
+self::dumpObject(\$user);
+self::dumpObjectArray(\$posts);
+        ";
+
+        $message .= self::highlightText($text, true);
+        $message .= '<pre>'. self::dumpObject($user).'</pre>';
+        $message .= '<pre>'. self::dumpObjectArray($posts).'</pre><br>';
+
+        //
+        $message .= '<h3><strong>'.__d('demo', 'Relations: belongsToMany').'</strong></h3><br>';
+
+        //
+        $model = new Student();
+
+        $student = $model->find(1);
+
+        $courses = $student->courses;
+
+        $text = "
+\$model = new Student();
+
+\$student = \$model->find(1);
+
+\$courses = \$student->courses;
+
+self::dumpObject(\$student);
+self::dumpObjectArray(\$posts);
+        ";
+
+        $message .= self::highlightText($text, true);
+        $message .= '<pre>'. $this->model->lastSqlQuery().'</pre>';
+        $message .= '<pre>'. self::dumpObject($student).'</pre>';
+        $message .= '<pre>'. self::dumpObjectArray($courses).'</pre><br>';
+
+        //
+        $model = new Course();
+
+        $course = $model->find(1);
+
+        $students = $course->students;
+
+        $text = "
+\$model = new Course();
+
+\$course = \$course->find(1);
+
+\$students = \$course->students;
+
+self::dumpObject(\$course);
+self::dumpObjectArray(\$students);
+        ";
+
+        $message .= self::highlightText($text, true);
+        $message .= '<pre>'. $this->model->lastSqlQuery().'</pre>';
+        $message .= '<pre>'. self::dumpObject($course).'</pre>';
+        $message .= '<pre>'. self::dumpObjectArray($students).'</pre><br>';
+
         // Setup the View variables.
         $this->title(__d('demo', 'ORM - Object Relational Model'));
 
@@ -220,15 +370,27 @@ var_dump(\$result);
     private static function dumpObject($object)
     {
         if($object === null) {
-            return 'null'; // Empty string.
+            return 'null'; // NULL.
+        }
+        else if($object === false) {
+            return 'false'; // Boolean false.
+        }
+        else if(is_string($object)) {
+            return $object;
+        }
+        else if($object instanceof BaseModel) {
+            return (string) $object;
         }
 
-        return (string) $object;
+        //return var_export($object);
     }
 
     private static function dumpObjectArray($data)
     {
-        if($data === false) {
+        if($data === null) {
+            return 'null'; // NULL.
+        }
+        else if($data === false) {
             return 'false'; // Empty string.
         }
 

--- a/app/Modules/Demo/Models/Category.php
+++ b/app/Modules/Demo/Models/Category.php
@@ -19,7 +19,7 @@ class Category extends BaseModel
 
     public function posts()
     {
-        return $this->hasMany('App\Modules\Demo\Post', 'category_id');
+        return $this->hasMany('App\Modules\Demo\Models\Post', 'category_id');
     }
 
 }

--- a/app/Modules/Demo/Models/Course.php
+++ b/app/Modules/Demo/Models/Course.php
@@ -9,11 +9,17 @@ class Course extends BaseModel
 {
     protected $tableName = 'courses';
 
+    protected $relations = array('students');
+
 
     public function __construct()
     {
         parent::__construct();
     }
 
+    public function students()
+    {
+        return $this->belongsToMany('App\Modules\Demo\Models\Student', 'course_student', 'course_id', 'student_id');
+    }
 
 }

--- a/app/Modules/Demo/Models/Post.php
+++ b/app/Modules/Demo/Models/Post.php
@@ -9,7 +9,7 @@ class Post extends BaseModel
 {
     protected $tableName = 'posts';
 
-    protected $relations = array('user', 'category');
+    protected $relations = array('author', 'category');
 
 
     public function __construct()
@@ -19,12 +19,12 @@ class Post extends BaseModel
 
     public function author()
     {
-        return $this->belongsTo('App\Modules\Demo\User', 'author_id');
+        return $this->belongsTo('App\Modules\Demo\Models\User', 'author_id');
     }
 
     public function category()
     {
-        return $this->belongsTo('App\Modules\Demo\Category', 'category_id');
+        return $this->belongsTo('App\Modules\Demo\Models\Category', 'category_id');
     }
 
 }

--- a/app/Modules/Demo/Models/Profile.php
+++ b/app/Modules/Demo/Models/Profile.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Modules\Demo\Models;
+
+use Nova\ORM\Model as BaseModel;
+
+
+class Profile extends BaseModel
+{
+    protected $tableName = 'profiles';
+
+    protected $relations = array('user');
+
+
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    public function user()
+    {
+        return $this->belongsTo('\App\Modules\Demo\Models\User', 'user_id');
+    }
+
+}

--- a/app/Modules/Demo/Models/Student.php
+++ b/app/Modules/Demo/Models/Student.php
@@ -9,11 +9,17 @@ class Student extends BaseModel
 {
     protected $tableName = 'students';
 
+    protected $relations = array('courses');
+
 
     public function __construct()
     {
         parent::__construct();
     }
 
+    public function courses()
+    {
+        return $this->belongsToMany('App\Modules\Demo\Models\Course', 'course_student', 'student_id', 'course_id');
+    }
 
 }

--- a/app/Modules/Demo/Models/User.php
+++ b/app/Modules/Demo/Models/User.php
@@ -9,7 +9,7 @@ class User extends BaseModel
 {
     protected $tableName = 'users';
 
-    protected $relations = array('posts');
+    protected $relations = array('profile', 'posts');
 
 
     public function __construct()
@@ -17,9 +17,14 @@ class User extends BaseModel
         parent::__construct();
     }
 
+    public function profile()
+    {
+        return $this->hasOne('App\Modules\Demo\Models\Profile', 'user_id');
+    }
+
     public function posts()
     {
-        return $this->hasMany('App\Modules\Demo\Post', 'author_id');
+        return $this->hasMany('App\Modules\Demo\Models\Post', 'author_id');
     }
 
 }

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,9 @@
         "siriusphp/filtration": "~1.2",
         "siriusphp/input": "dev-master",
         "lichtner/fluentpdo": "dev-master",
-        "phpfastcache/phpfastcache": "3.0.*"
+        "phpfastcache/phpfastcache": "3.0.*",
+        "filp/whoops": "*",
+        "monolog/monolog": "1.13.1"
     },
     "require-dev": {
         "phpunit/phpunit": "5.1.4",

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,3 +1,9 @@
+# Use PHP55 as default
+AddHandler application/x-httpd-php55 .php
+<IfModule mod_suphp.c>
+    suPHP_ConfigPath /opt/php55/lib
+</IfModule>
+
 # Remove ETags as resources are sent with far-future expires headers.
 # http://developer.yahoo.com/performance/rules.html#etags.
 

--- a/scripts/nova_testing.sql
+++ b/scripts/nova_testing.sql
@@ -3,7 +3,7 @@
 -- http://www.phpmyadmin.net
 --
 -- Host: localhost
--- Generation Time: Jan 13, 2016 at 01:04 PM
+-- Generation Time: Jan 14, 2016 at 02:19 AM
 -- Server version: 5.5.40-36.1
 -- PHP Version: 5.4.23
 
@@ -17,7 +17,7 @@ SET time_zone = "+00:00";
 /*!40101 SET NAMES utf8 */;
 
 --
--- Database: `nova_testing`
+-- Database: `eliana_nova`
 --
 
 -- --------------------------------------------------------
@@ -116,6 +116,31 @@ INSERT INTO `nova_posts` (`id`, `author_id`, `category_id`, `title`, `content`) 
 -- --------------------------------------------------------
 
 --
+-- Table structure for table `nova_profiles`
+--
+
+CREATE TABLE IF NOT EXISTS `nova_profiles` (
+  `id` int(11) unsigned NOT NULL,
+  `user_id` int(11) unsigned NOT NULL,
+  `realname` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `country` varchar(100) COLLATE utf8_unicode_ci DEFAULT NULL
+) ENGINE=MyISAM AUTO_INCREMENT=7 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+
+--
+-- Dumping data for table `nova_profiles`
+--
+
+INSERT INTO `nova_profiles` (`id`, `user_id`, `realname`, `country`) VALUES
+(1, 1, 'Administrator', 'Italy'),
+(2, 2, 'Marcus Spears', 'UK'),
+(3, 3, 'Michael White', 'USA'),
+(4, 4, 'John Kennedy', 'UK'),
+(5, 5, 'Mark Black', 'Australia'),
+(6, 2, 'Marcus Williams', 'UK');
+
+-- --------------------------------------------------------
+
+--
 -- Table structure for table `nova_students`
 --
 
@@ -146,7 +171,7 @@ CREATE TABLE IF NOT EXISTS `nova_users` (
   `id` int(11) unsigned NOT NULL,
   `username` varchar(255) NOT NULL,
   `email` varchar(255) NOT NULL
-) ENGINE=InnoDB AUTO_INCREMENT=11 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB AUTO_INCREMENT=370 DEFAULT CHARSET=utf8;
 
 --
 -- Dumping data for table `nova_users`
@@ -188,6 +213,12 @@ ALTER TABLE `nova_posts`
   ADD PRIMARY KEY (`id`);
 
 --
+-- Indexes for table `nova_profiles`
+--
+ALTER TABLE `nova_profiles`
+  ADD PRIMARY KEY (`id`);
+
+--
 -- Indexes for table `nova_students`
 --
 ALTER TABLE `nova_students`
@@ -218,6 +249,11 @@ ALTER TABLE `nova_courses`
 --
 ALTER TABLE `nova_posts`
   MODIFY `id` int(11) NOT NULL AUTO_INCREMENT,AUTO_INCREMENT=8;
+--
+-- AUTO_INCREMENT for table `nova_profiles`
+--
+ALTER TABLE `nova_profiles`
+  MODIFY `id` int(11) unsigned NOT NULL AUTO_INCREMENT,AUTO_INCREMENT=7;
 --
 -- AUTO_INCREMENT for table `nova_students`
 --

--- a/system/Config/bootstrap.php
+++ b/system/Config/bootstrap.php
@@ -7,6 +7,7 @@
  * @date December 15th, 2015
  */
 
+// Framework
 use Nova\Packages\Manager as Packages;
 use Nova\Modules\Manager as Modules;
 use Nova\Events\Manager as Events;
@@ -14,6 +15,16 @@ use Nova\Net\Session;
 use Nova\Net\Router;
 use Nova\Config;
 use Nova\Logger;
+
+// Monolog
+use Monolog\Logger as MonologLogger;
+use Monolog\Handler\StreamHandler as MonologHandler;
+
+// Whoops!
+use Whoops\Run as WhoopsRunner;
+use Whoops\Handler\PrettyPageHandler as WhoopsPrettyHandler;
+use Whoops\Handler\PlainTextHandler as WhoopsPlainHandler;
+
 
 /** Prepare the current directory for configuration files. */
 $configDir = APPPATH .'Config' .DS;
@@ -41,9 +52,24 @@ date_default_timezone_set(Config::get('timezone'));
 /** Initialize the Logger. */
 Logger::initialize();
 
-/** Set the Framework Exception and Error Handlers. */
+/** Set the Framework Exception and Error Handlers using the native \Nova\Logger. */
 set_exception_handler('Nova\Logger::ExceptionHandler');
 set_error_handler('Nova\Logger::ErrorHandler');
+
+/** Set the Framework Exception and Error Handlers using the Monolog and Whoops. */
+/*
+$monolog = new MonologLogger('system');
+
+$monolog->pushHandler(new MonologHandler(BASEPATH .'storage' .DS .'logs' .DS .'app.log', MonologLogger::ERROR));
+
+// Whoops: php errors for cool kids
+$whoops = new WhoopsRunner();
+
+$whoops->pushHandler(new WhoopsPrettyHandler());
+$whoops->pushHandler(new WhoopsPlainHandler($monolog));
+
+$whoops->register();
+*/
 
 /** Bootstrap the active Packages. */
 Packages::bootstrap();

--- a/system/Database/Connection.php
+++ b/system/Database/Connection.php
@@ -74,6 +74,8 @@ abstract class Connection extends PDO
         parent::__construct($dsn, $username, $password, $options);
 
         $this->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+        $this->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
         $this->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, $fetchMethod);
     }
 

--- a/system/ORM/Engine.php
+++ b/system/ORM/Engine.php
@@ -1,0 +1,203 @@
+<?php
+/**
+ * Engine
+ *
+ * @author Virgil-Adrian Teaca - virgil@giulianaeassociati.com
+ * @version 3.0
+ * @date January 14th, 2016
+ */
+
+namespace Nova\ORM;
+
+use Nova\Helpers\Inflector;
+use Nova\Database\Connection;
+use Nova\Database\Manager as Database;
+
+
+abstract class Engine
+{
+    /*
+     * The used \Nova\Database\Connection instance.
+     */
+    protected $db = null;
+
+    /*
+     * Internal static Cache.
+     */
+    protected static $cache = array();
+
+    /*
+     * There is stored the called Class name.
+     */
+    protected $className;
+
+    /**
+     * The Table Metadata.
+     */
+    protected $fields = array();
+
+    /**
+     * There we store the Model Attributes (its Data).
+     */
+    protected $attributes = array();
+
+    /**
+     * The Table name belonging to this Model.
+     */
+    protected $tableName;
+
+    /*
+     * Constructor
+     */
+    public function __construct($connection = 'default')
+    {
+        $this->className = get_class($this);
+
+        if($connection instanceof Connection) {
+            $this->db = $connection;
+        } else {
+            $this->db = Database::getConnection($connection);
+        }
+
+        // Setup the Table name, if is empty.
+        if (empty($this->tableName)) {
+            // Try the best to guess the Table name: User -> users
+            $classPath = str_replace('\\', '/', $this->className);
+
+            $tableName = Inflector::pluralize(basename($classPath));
+
+            $this->tableName = Inflector::tableize($tableName);
+        }
+
+        // Get the Table Fields.
+        /* The Table Fields should be specified into form:
+        array(
+            'first_field' => 'string'
+            'other_field' => 'int'
+            'third_field' => 'string'
+        );
+        */
+
+        if(! empty($this->fields)) {
+            // Do nothing.
+        }
+        else if ($this->getCache('$tableFields$') === null) {
+            $fields = $this->db->getTableFields($this->table());
+
+            foreach($fields as $field => $fieldInfo) {
+                $this->fields[$field] = $fieldInfo['type'];
+            }
+
+            $this->setCache('$tableFields$', $this->fields);
+        } else {
+            $this->fields = $this->getCache('$tableFields$');
+        }
+    }
+
+    public function getTableName()
+    {
+        return $this->tableName;
+    }
+
+    /**
+     * Getter for the table name.
+     *
+     * @return string The name of the table used by this class (including the DB_PREFIX).
+     */
+    public function table()
+    {
+        return DB_PREFIX .$this->tableName;
+    }
+
+    //--------------------------------------------------------------------
+    // Caching Management Methods
+    //--------------------------------------------------------------------
+
+    protected function getCache($name)
+    {
+        $token = $this->className .'_' .$name;
+
+        if (isset(self::$cache[$token])) {
+            return self::$cache[$token];
+        }
+
+        return null;
+    }
+
+    protected function setCache($name, $value)
+    {
+        $token = $this->className .'_' .$name;
+
+        self::$cache[$token] = $value;
+    }
+
+    protected function clearCache($name)
+    {
+        $token = $this->className .'_' .$name;
+
+        if (isset(self::$cache[$token])) {
+            unset(self::$cache[$token]);
+        }
+    }
+
+    protected function hasCached($name)
+    {
+        $token = $this->className .'_' .$name;
+
+        return isset(self::$cache[$token]);
+    }
+
+    //--------------------------------------------------------------------
+    // Attributes handling Methods
+    //--------------------------------------------------------------------
+
+    public function setAttributes($attributes)
+    {
+        $this->hydrate($attributes);
+    }
+
+    public function attributes()
+    {
+        return $this->attributes;
+    }
+
+    public function setAttribute($name, $value)
+    {
+        $this->attributes[$name] = $value;
+    }
+
+    public function attribute($name)
+    {
+        return isset($this->attributes[$name]) ? $this->attributes[$name] : null;
+    }
+
+    //--------------------------------------------------------------------
+    // Data Conversion Methods
+    //--------------------------------------------------------------------
+
+    public function toArray()
+    {
+        return $this->attributes;
+    }
+
+    public function toObject()
+    {
+        $object = new stdClass();
+
+        foreach ($this->attributes as $key => $value) {
+            $object->$key = $value;
+        }
+
+        return $object;
+    }
+
+    //--------------------------------------------------------------------
+    // Debug Methods
+    //--------------------------------------------------------------------
+
+    public function lastSqlQuery()
+    {
+        return $this->db->lastSqlQuery();
+    }
+
+}

--- a/system/ORM/Query/Builder.php
+++ b/system/ORM/Query/Builder.php
@@ -1,0 +1,210 @@
+<?php
+/**
+ * Base
+ *
+ * @author Virgil-Adrian Teaca - virgil@giulianaeassociati.com
+ * @version 3.0
+ * @date January 14th, 2016
+ */
+
+namespace Nova\ORM\Query;
+
+use Nova\Database\Connection;
+
+
+trait Builder
+{
+    /**
+     * Temporary select's WHERE attributes.
+     */
+    protected $tempWheres = array();
+
+    /**
+     * Temporary select's ORDER attribute.
+     */
+    protected $selectOrder = null;
+
+    /**
+     * Temporary select's LIMIT attribute.
+     */
+    protected $selectLimit = null;
+
+    /**
+     * Temporary select's OFFSET attribute.
+     */
+    protected $selectOffset = null;
+
+
+    /*
+     * Constructor
+     */
+    public function __construct()
+    {
+    }
+
+    //--------------------------------------------------------------------
+    // Query Building Methods
+    //--------------------------------------------------------------------
+
+    public function where($field, $value = '')
+    {
+        if(! empty($field)) {
+            $this->tempWheres[$field] = $value;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Limit results
+     *
+     * @param int $limit
+     * @return BaseModel $this
+     */
+    public function limit($limit = null)
+    {
+        if (! is_null($limit) && ! is_integer($limit)) {
+            throw new \UnexpectedValueException(__d('system', 'Invalid parameter'));
+        }
+
+        $this->selectLimit  = $limit;
+
+        return $this;
+    }
+
+    /**
+     * Offset
+     *
+     * @param int $offset
+     * @return BaseModel $this
+     */
+    public function offset($offset = null)
+    {
+        if (! is_null($offset) && ! is_integer($offset)) {
+            throw new \UnexpectedValueException(__d('system', 'Invalid parameter'));
+        }
+
+        $this->selectOffset = $offset;
+
+        return $this;
+    }
+
+    /**
+     * Order by
+     * @param mixed $order
+     * @return BaseModel $this
+     */
+    public function orderBy($order)
+    {
+        if(empty($order)) {
+            $this->selectOrder = null;
+        }
+        // Ccheck if the Field contains conditions.
+        else if (strpos($order, ' ') !== false) {
+            // Simplify the white spaces on Field.
+            $order = preg_replace('/\s+/', ' ', trim($order));
+
+            // Explode the field into its components.
+            $segments = explode(' ', $order);
+
+            if(count($segments) !== 2) {
+                throw new \UnexpectedValueException(__d('system', 'Invalid parameter'));
+            }
+
+            $field = $segments[0];
+            $sense = strtoupper($segments[1]);
+
+            if(($sense != 'ASC') && ($sense != 'DESC')) {
+                throw new \UnexpectedValueException(__d('system', 'Invalid parameter'));
+            }
+
+            $this->selectOrder = $field .' ' .$sense;
+        }
+        else {
+            $this->selectOrder = $order;
+        }
+
+        return $this;
+    }
+
+    protected function resetState()
+    {
+        // Reset our select WHEREs
+        $this->tempWheres = array();
+
+        // Reset our select ORDER
+        $this->selectOrder = null;
+
+        // Reset our select LIMIT
+        $this->selectLimit = null;
+
+        // Reset our select OFFSET
+        $this->selectOffset = null;
+    }
+
+    /**
+     * Set where
+     * @param array $params
+     * @return array
+     */
+    protected function setWhere(array $params = array())
+    {
+        if (empty($params)) {
+            return $this->tempWheres;
+        }
+
+        // Get the WHERE condition.
+        $condition = array_shift($params);
+
+        if ($condition == null) {
+            // Remove all previous defined conditions from our own WHEREs array, too.
+            $this->tempWheres = array();
+        } else if (is_array($condition)) {
+            // Is given an array of Conditions; merge them into our own WHEREs array.
+            $this->tempWheres = array_merge($this->tempWheres, $condition);
+        } else if (count($params) == 1) {
+            // Store the condition and its value.
+            $this->tempWheres[$condition] = array_shift($params);
+        } else if (count($params) == 2) {
+            $operator = array_shift($params);
+
+            if (! in_array($operator, Connection::$whereOperators, true)) {
+                throw new \UnexpectedValueException(__d('system', 'Second parameter is invalid'));
+            }
+
+            $condition = sprintf('%s $s ?', $condition, $operator);
+
+            // Store the composed condition and its value.
+            $this->tempWheres[$condition] = array_shift($params);
+        } else {
+            throw new \UnexpectedValueException(__d('system', 'Invalid number of parameters'));
+        }
+
+        return $this->tempWheres;
+    }
+
+    /**
+     * Wheres
+     * @return array
+     */
+    protected function wheres()
+    {
+        return $this->tempWheres;
+    }
+
+    protected function getOrder()
+    {
+        return $this->selectOrder;
+    }
+
+    protected function getLimit()
+    {
+        return $this->selectLimit;
+    }
+
+    protected function getOffset()
+    {
+        return $this->selectOffset;
+    }
+
+}

--- a/system/ORM/Relation.php
+++ b/system/ORM/Relation.php
@@ -17,8 +17,10 @@ abstract class Relation
 
     public function __construct($className)
     {
-        if(! class_exists($$className)) {
-            throw new \Exception(__d('system', 'No valid Class is given: {0}', $$className));
+        $className = sprintf('\\%s', ltrim($className, '\\'));
+
+        if(! class_exists($className)) {
+            throw new \Exception(__d('system', 'No valid Class is given: {0}', $className));
         }
 
         // Setup the instance of Target Model.

--- a/system/ORM/Relation/BelongsTo.php
+++ b/system/ORM/Relation/BelongsTo.php
@@ -15,7 +15,8 @@ use Nova\ORM\Relation;
 
 class BelongsTo extends Relation
 {
-    protected $primaryKey;
+    protected $foreignKey;
+    protected $otherKey;
 
 
     public function __construct($className, Model $model, $otherKey = null)
@@ -28,12 +29,15 @@ class BelongsTo extends Relation
         }
 
         // The primaryKey is associated to target Model.
-        $this->primaryKey = $model->attribute($otherKey);
+        $this->primaryKey = $this->model->getPrimaryKey();
+
+        // The otherKey is associated to target Model.
+        $this->otherKey = $model->attribute($otherKey);
     }
 
     public function get()
     {
-        return $this->model->find($this->primaryKey);
+        return $this->model->findBy($this->primaryKey, $this->otherKey);
     }
 
 }

--- a/system/ORM/Relation/BelongsToMany.php
+++ b/system/ORM/Relation/BelongsToMany.php
@@ -11,15 +11,20 @@ namespace Nova\ORM\Relation;
 
 use Nova\ORM\Model;
 use Nova\ORM\Relation;
-use Nova\ORM\Relation\JoiningPivot;
+use Nova\ORM\Relation\Joining\Pivot as JoiningPivot;
 
 
 class BelongsToMany extends Relation
 {
+    use \Nova\ORM\Query\Builder;
+
+    //
     protected $pivot;
 
     protected $foreignKey;
+
     protected $otherKey;
+    protected $otherId;
 
 
     public function __construct($className, Model $model, $joinTable, $foreignKey, $otherKey = null)
@@ -35,15 +40,24 @@ class BelongsToMany extends Relation
         $this->pivot = new JoiningPivot($joinTable, $foreignKey, $otherKey);
 
         // The primaryKey is associated to host Model.
-        $this->foreignKey = $foreignKey;
+        $this->foreignKey = $otherKey;
 
         // The primaryKey is the foreignKey of the target Model.
-        $this->otherKey = $otherKey;
+        $this->otherKey = $foreignKey;
+
+        $this->otherId = $model->getPrimaryKey();
     }
 
     public function get()
     {
-        return false;
+        $joinTable = $this->pivot->table();
+
+        return $this->model
+            ->where($this->wheres())
+            ->orderBy($order)
+            ->limit($limit)
+            ->offset($offset)
+            ->fetchWithPivot($joinTable, $this->foreignKey, $this->otherKey, $this->otherId);
     }
 
     public function &pivot()

--- a/system/ORM/Relation/HasMany.php
+++ b/system/ORM/Relation/HasMany.php
@@ -15,6 +15,9 @@ use Nova\ORM\Relation;
 
 class HasMany extends Relation
 {
+    use \Nova\ORM\Query\Builder;
+
+    //
     protected $foreignKey;
     protected $primaryKey;
 
@@ -32,7 +35,16 @@ class HasMany extends Relation
 
     public function get()
     {
-        return $this->model->findManyBy($this->foreignKey, $this->primaryKey);
+        $order = $this->getOrder();
+        $limit = $this->getLimit();
+        $offset = $this->getOffset();
+
+        return $this->model
+            ->where($this->wheres())
+            ->orderBy($order)
+            ->limit($limit)
+            ->offset($offset)
+            ->findManyBy($this->foreignKey, $this->primaryKey);
     }
 
 }

--- a/system/ORM/Relation/Joining/Pivot.php
+++ b/system/ORM/Relation/Joining/Pivot.php
@@ -7,20 +7,17 @@
  * @date January 13th, 2016
  */
 
-namespace Nova\ORM;
+namespace Nova\ORM\Relation\Joining;
 
 use Nova\Database\Connection;
 use Nova\Database\Manager as Database;
 
+use Nova\ORM\Engine;
 use Nova\ORM\Model;
 
 
-class JoiningPivot
+class Pivot extends Engine
 {
-    protected $tableName;
-
-    protected $db;
-
     protected $foreignKey;
     protected $otherKey;
 
@@ -29,18 +26,14 @@ class JoiningPivot
     {
         $this->tableName = $tableName;
 
-        $this->db = Database::getConnection($connection);
+        // Execute the parent Constructor, after setting up the Table name.
+        parent::__construct();
 
         // The foreignKey is associated to host Model.
         $this->foreignKey = $foreignKey;
 
         // The otherKey is associated to target Model.
         $this->otherKey = $otherKey;
-    }
-
-    public function table()
-    {
-        return DB_PREFIX .$this->tableName;
     }
 
     public function attach($params)


### PR DESCRIPTION
Okay, now the ORM's **Model Relations** works as supposed into **hasOne, hasMany, belongsTo and belongsToMany** incarnations, still needing to be completed the **Pivot** engine for **belongsToMany** to permit saving the relations.

To note that **hasMany** and **belongsToMany** support basic QueryBuilding, permitting even commands similar to:

```php
$courses = $student->courses()->where('category_id', 3)->limit(20)->offset(40)->get();
``` 