### PR TITLE
While the shiny Tests wants 'prepare($statement, $options = null)' th…

### DIFF
--- a/system/Database/Connection.php
+++ b/system/Database/Connection.php
@@ -257,8 +257,10 @@ abstract class Connection extends PDO
     /**
      * @return Statement
      */
-    public function prepare($statement, $options = NULL)
+    public function prepare($statement, $options = null)
     {
+        $options = $options ? $options : array();
+
         return new Statement(parent::prepare($statement, $options), $this);
     }
 


### PR DESCRIPTION
…e real PHP 5.6.x wants prepare($statement, $options = array())'

All Hail to Tests to Ensure Code Messing Systems!