### PR TITLE
Automatically tableize the Template URLs, to properly be counterpart …

### DIFF
--- a/nova/system/Helpers/Url.php
+++ b/nova/system/Helpers/Url.php
@@ -11,6 +11,7 @@
 namespace Helpers;
 
 use Helpers\Session;
+use Helpers\Inflector;
 
 /**
  * Collection of methods for working with urls.
@@ -68,8 +69,9 @@ class Url
      */
     public static function templatePath($custom = TEMPLATE)
     {
-        return DIR.'Templates/'.$custom.'/';
+        $template = Inflector::tableize($custom);
 
+        return DIR.'templates/' .$template .'/';
     }
 
     /**
@@ -80,7 +82,9 @@ class Url
      */
     public static function relativeTemplatePath($custom = TEMPLATE)
     {
-        return "Templates/".$custom."/";
+        $template = Inflector::tableize($custom);
+
+        return "templates/" .$template ."/";
     }
 
     /**


### PR DESCRIPTION
…to the new Routing's File Serving

The basic idea is that a Template path like:

```
nova\app\Templates\NiceTheme/
```

Will become:

```
/templates/nice_theme/
```

The actual Routing known how to interpret this URI path and to look in the right path, transforming that path back into CamelCase.