### PR TITLE
URL Helper for resource URI transformation in the Modules case

### DIFF
--- a/nova/system/Helpers/Url.php
+++ b/nova/system/Helpers/Url.php
@@ -62,6 +62,23 @@ class Url
     }
 
     /**
+     * Created the absolute address to the assets folder.
+     *
+     * @param  string|null $module
+     * @return string url to assets folder
+     */
+    public static function resourcePath($module = null)
+    {
+        if($module !== null) {
+            $path = sprintf('modules/%s/', Inflector::tableize($module));
+        } else {
+            $path = '';
+        }
+
+        return DIR .$path .'assets/';
+    }
+
+    /**
      * Created the absolute address to the template folder.
      *
      * @param  boolean $custom


### PR DESCRIPTION
The basic idea is to help the URI path transformation for the resources located into Modules and the base assets folder. Then the following call:

```php
$path = Url::resourcePath('FileManager');
``` 

will result into:

```
/modules/file_manager/assets/
```

With no parameters will return:

```
/assets/
```

Which correspond with the generic Assets directory. 