### PR TITLE
Improve the Routes Group handling into Core\Router

### DIFF
--- a/nova/system/Core/Router.php
+++ b/nova/system/Core/Router.php
@@ -23,7 +23,7 @@ class Router
 {
     private static $instance;
 
-    private static $routeGroup = '';
+    private static $routeGroups = array();
 
     /**
      * Array of routes
@@ -117,14 +117,14 @@ class Router
      */
     public static function group($group, $callback)
     {
-        // Set the current Routes Group
-        self::$routeGroup = trim($group, '/');
+        // Add the Route Group to the array.
+        array_push(self::$routeGroups, trim($group, '/'));
 
         // Call the Callback, to define the Routes on the current Group.
         call_user_func($callback);
 
-        // Reset the Routes Group to default (none).
-        self::$routeGroup = '';
+        // Removes the last Route Group from the array.
+        array_pop(self::$routeGroups);
     }
 
     /**
@@ -154,7 +154,11 @@ class Router
     {
         $method = strtoupper($method);
 
-        $pattern = ltrim(self::$routeGroup.'/'.$route, '/');
+        if (! empty(self::$routeGroups)) {
+            $pattern = implode('/', self::$routeGroups) .'/' .$route;
+        } else {
+            $pattern = $route;
+        }
 
         $route = new Route($method, $pattern, $callback);
 

--- a/nova/system/Core/Router.php
+++ b/nova/system/Core/Router.php
@@ -154,10 +154,10 @@ class Router
     {
         $method = strtoupper($method);
 
+        $pattern = ltrim($route, '/');
+
         if (! empty(self::$routeGroups)) {
-            $pattern = implode('/', self::$routeGroups) .'/' .$route;
-        } else {
-            $pattern = $route;
+            $pattern = implode('/', self::$routeGroups) .'/' .$pattern;
         }
 
         $route = new Route($method, $pattern, $callback);


### PR DESCRIPTION
This PR improve the Routes Group management into **Core\Router** making possible the use of recursive definition of those groups of Routes.

Example:

```php
Router::group('admin', function() { 
   Router::any('dashboard', 'App\Controllers\Admin\Dashboard@index');

   Router::group('blog', function() {
       Router::any('list', 'App\Controllers\Admin\Blog@list');
       Router::any('add', 'App\Controllers\Admin\Blog@add');
       Router::any('edit', 'App\Controllers\Admin\Blog@edit');
       Router::post('delete', 'App\Controllers\Admin\Blog@delete');
   });

   Router::any('settings', 'App\Controllers\Admin\Settings@manage');
});
```

This command is equivalent with:


```php
Router::any('admin/dashboard', 'App\Controllers\Admin\Dashboard@index');

Router::any('admin/blog/list', 'App\Controllers\Admin\Blog@list');
Router::any('admin/blog/add', 'App\Controllers\Admin\Blog@add');
Router::any('admin/blog/edit', 'App\Controllers\Admin\Blog@edit');
Router::post('admin/blog/delete', 'App\Controllers\Admin\Blog@delete');

Router::any('admin/settings', 'App\Controllers\Admin\Settings@manage');
```

